### PR TITLE
Create shared-net docker network for cross-project container communication

### DIFF
--- a/roles/supabase/tasks/main.yml
+++ b/roles/supabase/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Check if shared-net Docker network exists
+  command: docker network ls --format '{{ "{{ .Name }}" }}'
+  register: existing_networks
+  changed_when: false
+
+- name: Create shared-net Docker network if missing
+  docker_network:
+    name: shared-net
+    driver: bridge
+    state: present
+  when: ' "shared-net" not in existing_networks.stdout_lines '
+
 - name: Check if Supabase folder exists
   ansible.builtin.stat:
     path: "/home/{{ deploy_user }}/supabase"

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -60,6 +60,8 @@ services:
     volumes:
       - ./volumes/snippets:/app/snippets:Z
       - ./volumes/functions:/app/edge-functions:Z
+    networks:
+      - shared-net
 
   kong:
     container_name: supabase-kong
@@ -69,6 +71,7 @@ services:
       default:
         aliases:
           - api-gw
+      shared-net: {}
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 5s
@@ -233,6 +236,8 @@ services:
      
       # Uncomment to bypass nonce check in ID Token flow. Commonly set to true when using Google Sign In on mobile.
       #GOTRUE_EXTERNAL_SKIP_NONCE_CHECK: true
+    networks:
+      - shared-net
 
   rest:
     container_name: supabase-rest
@@ -257,6 +262,8 @@ services:
       [
         "postgrest"
       ]
+    networks:
+      - shared-net
 
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
@@ -298,6 +305,8 @@ services:
       SEED_SELF_HOST: "true"
       RUN_JANITOR: "true"
       DISABLE_HEALTHCHECK_LOGGING: "true"
+    networks:
+      - shared-net
 
 
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
@@ -359,6 +368,8 @@ services:
       S3_PROTOCOL_ACCESS_KEY_SECRET: ${S3_PROTOCOL_ACCESS_KEY_SECRET}
     volumes:
       - ./volumes/storage:/var/lib/storage:z
+    networks:
+      - shared-net
 
 
   imgproxy:
@@ -383,6 +394,8 @@ services:
       IMGPROXY_USE_ETAG: "true"
       IMGPROXY_AUTO_WEBP: ${IMGPROXY_AUTO_WEBP}
       IMGPROXY_MAX_SRC_RESOLUTION: 16.8
+    networks:
+      - shared-net
 
   meta:
     container_name: supabase-meta
@@ -400,6 +413,8 @@ services:
       PG_META_DB_USER: supabase_admin
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
       CRYPTO_KEY: ${PG_META_CRYPTO_KEY}  
+    networks:
+      - shared-net
   
   functions:
     container_name: supabase-edge-functions
@@ -431,6 +446,8 @@ services:
         "--main-service",
         "/home/deno/functions/main"
       ]
+    networks:
+      - shared-net
 
   analytics:
     container_name: supabase-analytics
@@ -478,6 +495,8 @@ services:
       # Uncomment to use Big Query backend for analytics
       # GOOGLE_PROJECT_ID: ${GOOGLE_PROJECT_ID}
       # GOOGLE_PROJECT_NUMBER: ${GOOGLE_PROJECT_NUMBER}
+    networks:
+      - shared-net
 
 
 
@@ -560,6 +579,8 @@ services:
       - /var/log/postgresql:/var/log/postgresql:Z
       # Mount SSL certs
       - /opt/postgres-certs:/etc/postgres/certs:ro
+    networks:
+      - shared-net
 
   vector:
     container_name: supabase-vector
@@ -591,6 +612,8 @@ services:
       ]
     security_opt:
       - "label=disable"
+    networks:
+      - shared-net
 
   # Update the DATABASE_URL if you are using an external Postgres database
 
@@ -646,7 +669,13 @@ services:
         "-c",
         "/app/bin/migrate && /app/bin/supavisor eval \"$$(cat /etc/pooler/pooler.exs)\" && /app/bin/server"
       ]
+    networks:
+      - shared-net
 
 volumes:
   db-config:
   deno-cache:
+
+networks:
+  shared-net:
+    external: true


### PR DESCRIPTION
Add shared Docker network to enable container-to-container communication between separate docker-compose projects

This allows the app (running in its own compose) to connect to Supabase services (running in another compose) using container names.