### PR TITLE
feat(migrate): add Layer 1 migration script from supabase.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,60 @@ Full documentation: **[docs/advanced-docs.md](docs/advanced-docs.md)**
 
 ---
 
+## 🚚 Migration from Supabase Cloud
+
+Once your self-hosted stack is running, you can migrate an existing Supabase
+Cloud project into it with a single command. The `migrate.sh` script is a
+**Layer 1 walking skeleton**: it migrates schema + data, auth users (UUIDs
+preserved), and storage objects, then prints a checklist of the manual steps
+that remain.
+
+### What migrates automatically
+
+- **Database schema + data** — `pg_dump`/`pg_restore` across Supabase-managed
+  schemas (`public`, `auth`, `storage`, `_realtime`, `graphql_public`,
+  `extensions`, `pgsodium`). Missing schemas are skipped with a warning.
+- **Auth users** — `auth.users` and `auth.identities` migrated with UUIDs
+  preserved. Password hashes migrate, so existing passwords still work; users
+  must log in again (sessions are not migrated).
+- **Storage objects** — copied via `rclone` from the Cloud S3 endpoint to your
+  self-hosted storage (read-only against the source).
+
+### What stays manual (printed at the end)
+
+Auth configuration, Edge Functions, cron jobs, webhooks, storage bucket
+configuration, and client env-var updates. The script prints a fixed checklist
+at the end — migration is incomplete but never silently incomplete.
+
+### Usage
+
+```bash
+# 1. Copy the example config and edit it
+cp env/migrate.example.yml env/migrate.yml
+# Edit env/migrate.yml: fill in the SOURCE (Cloud) and TARGET (self-hosted) sections
+
+# 2. Preview the migration plan (no changes made)
+./migrate.sh --config env/migrate.yml --dry-run
+
+# 3. Run the migration (non-interactive, for CI/automation)
+./migrate.sh --config env/migrate.yml --yes
+```
+
+### Invariants
+
+- **Read-only against the source.** Always. The script uses `pg_dump`
+  (inherently read-only) and `rclone copy` (not `sync`/`move`), and refuses to
+  run if `source.db_url == target.db_url`.
+- **Refuses a non-empty target.** Layer 1 migrates into a fresh instance only.
+- **No resumability.** A failure means starting over.
+- **Runs with no TTY.** `--yes` gates all prompts; colors auto-disable.
+
+See [docs/designs/migration-layer-1.md](docs/designs/migration-layer-1.md) for
+the full design and [docs/test-cases/migration-layer-1.md](docs/test-cases/migration-layer-1.md)
+for the test matrix.
+
+---
+
 ## 📄 License
 
 MIT

--- a/docs/designs/migration-layer-1.md
+++ b/docs/designs/migration-layer-1.md
@@ -1,0 +1,297 @@
+# Design Canvas: Migration Script (Layer 1) — `migrate.sh`
+
+**Issue:** #99 — Migration script from supabase.com
+**Labels:** feature, migration, layer-1
+**Status:** Approved (autonomous mode — no interactive approval gate)
+
+---
+
+## 1. Goal
+
+A single command that takes a Supabase Cloud project and migrates it end-to-end
+into a freshly installed self-hosted instance (this repo's own stack), accepting
+downtime and a short list of manual steps printed at the end.
+
+```bash
+./migrate.sh --config env/migrate.yml --yes
+```
+
+This is the **walking skeleton**: the entire functional perimeter touched, none
+of it deeply. Incomplete, but never silently incomplete.
+
+---
+
+## 2. Non-Goals (Deliberately excluded — each has its own layer)
+
+- Verification / dry-run
+- Session continuity / resumability
+- Auth config import (manual checklist only at this layer)
+- Downtime reduction
+- Edge Functions migration (listed as manual steps)
+- Cron jobs / webhooks migration (listed as manual steps)
+- Storage bucket config reconciliation (objects only, no bucket config)
+
+---
+
+## 3. Fidelity Contract (what "done" means at this layer)
+
+| Surface | After this issue |
+|---|---|
+| Schema + data | Dumped and restored, including Supabase-managed schemas |
+| Roles | `anon`, `authenticated`, `service_role` recreated; custom roles best-effort |
+| Auth users | Migrated with UUIDs preserved — users must log in again |
+| Auth configuration | Manual, printed as a checklist |
+| Storage objects | Copied — no reconciliation, no bucket config |
+| Edge Functions | Not migrated — listed as manual steps |
+| Cron jobs, webhooks | Not migrated — listed as manual steps |
+| Downtime | A maintenance window, accepted and documented |
+| Restartability | None. A failure means starting over |
+
+---
+
+## 4. Conventions (must match `setup.sh`)
+
+- **YAML config file**, non-interactive by default.
+- **Flags are verbs only**: `--config <path>`, `--yes`, `--dry-run`, `--help`, `-v/--verbose`.
+  No `--config=foo` form (matches `setup.sh`'s `case` parser).
+- **Read-only against the source project. Always, at every layer.** This is a hard
+  invariant — enforced by (a) using only read-only `pg_dump`/`pg_restore` flags and
+  read-only S3 `GET`/`LIST` via rclone, and (b) a preflight assertion that the source
+  DSN is not the target DSN.
+- **Refuses to run against a non-empty target.** A preflight check counts relations
+  in `public` and rows in `auth.users`; if either is non-zero, abort before touching
+  anything.
+- **Runs with no TTY attached.** All prompts gated behind `--yes`; colors disabled
+  when `[[ -t 1 ]]` is false (same idiom as `setup.sh`).
+- **Logging helpers** (`log`/`ok`/`warn`/`die`) copied verbatim from `setup.sh` so the
+  two scripts feel like one tool.
+- **YAML parsing** via the same `python3 -c 'import yaml'` helper pattern (`cfg_get`/
+  `cfg_bool`), so no new runtime dependency is introduced.
+
+---
+
+## 5. Inputs (`env/migrate.example.yml`)
+
+A new example config, separate from `config.example.yml` (migration is an
+opt-in operation, not part of install). Copied to `env/migrate.yml` by the
+operator and edited.
+
+```yaml
+# Migration configuration — copy to env/migrate.yml and edit.
+# READ-ONLY against source. The script refuses to write to the source project.
+
+source:
+  # Supabase Cloud project ref (found in Dashboard URL / Settings / API).
+  project_ref: changeit            # e.g. abcdefghijklmnop
+
+  # Direct Postgres connection string to the Cloud project's pooler.
+  # Use the TRANSACTION/SESSION mode URL (port 6543 or 5432 per your pooler).
+  # Must be a libpq DSN. The script opens it READ-ONLY.
+  db_url: changeit                 # postgresql://postgres.[ref]:[pwd]@db.[ref].supabase.co:6543/postgres
+
+  # S3-compatible storage endpoint credentials (Supabase Cloud S3 API).
+  # Found in Dashboard / Settings / Storage.
+  storage_endpoint: changeit       # https://[ref].supabase.co/storage/v1
+  storage_access_key: changeit
+  storage_secret_key: changeit
+  storage_region: changeit         # e.g. us-east-1
+
+target:
+  # Self-hosted Postgres DSN (the stack this repo deploys).
+  # Default matches the local docker-compose service name + default password.
+  db_url: postgresql://postgres:postgres@localhost:5432/postgres
+
+  # Self-hosted storage endpoint (Kong /storage/v1).
+  storage_endpoint: http://localhost:8000/storage/v1
+  storage_access_key: changeit     # from env/supabase.yml s3_protocol_access_key_id
+  storage_secret_key: changeit     # from env/supabase.yml s3_protocol_access_key_secret
+  storage_region: us-east-1
+
+# Tools — paths to required binaries. Defaults resolve via PATH.
+tools:
+  pg_dump: pg_dump
+  pg_restore: pg_restore
+  rclone: rclone
+  psql: psql
+```
+
+### Validation rules
+
+- `source.project_ref` must not be `changeit`.
+- `source.db_url` must not be `changeit` and must start with `postgresql://` (or
+  `postgres://`).
+- `target.db_url` must start with `postgresql://` and must **not equal**
+  `source.db_url` (read-only-source invariant).
+- `source.storage_*` and `target.storage_*` must not be `changeit`.
+- Required binaries (`pg_dump`, `pg_restore`, `rclone`, `psql`) must be on PATH.
+
+---
+
+## 6. Execution Phases
+
+```
+Phase 0: Preflight
+  ├─ parse args (--config, --yes, --dry-run, --help, -v)
+  ├─ load + validate migrate.yml (cfg_get / cfg_bool helpers)
+  ├─ assert required binaries on PATH
+  ├─ assert source.db_url != target.db_url
+  ├─ assert target is empty (count relations in public + rows in auth.users)
+  └─ if --dry-run: print plan and exit 0
+
+Phase 1: Database — schema + data
+  ├─ pg_dump source (full, custom format, includes extensions + roles)
+  │     flags: --format=custom --no-owner --no-privileges --clean --if-exists
+  │     + --section=pre-data --section=post-data --section=data
+  │     + --schema=public --schema=auth --schema=storage --schema=_realtime
+  │       --schema=graphql_public --schema=extensions --schema=pgsodium
+  │       (best-effort: missing schemas are skipped with a warning, not fatal)
+  ├─ stream into pg_restore target
+  │     flags: --no-owner --no-privileges --clean --if-exists
+  │     + --exit-on-error for the pre-data section only
+  └─ on failure: die() with the failing command + tail of the log
+
+Phase 2: Auth users (UUIDs preserved)
+  ├─ pg_dump auth.users auth.identities from source (data-only, INSERT copy)
+  ├─ pg_restore into target
+  └─ NOTE: users must log in again (password hashes migrate, but sessions do not)
+
+Phase 3: Storage objects (rclone copy)
+  ├─ configure rclone remote for source S3 endpoint (read-only)
+  ├─ configure rclone remote for target S3 endpoint
+  ├─ rclone copy source:bucket target:bucket --progress=no
+  └─ on failure: warn (storage is best-effort at this layer) + add to manual report
+
+Phase 4: Manual-steps report
+  ├─ print a fixed checklist of everything NOT migrated
+  └─ exit 0
+```
+
+### Read-only-source enforcement
+
+- `pg_dump` is inherently read-only (no `--write` flag exists).
+- `rclone copy` (not `sync`, not `move`) — source is never mutated.
+- A preflight assertion `source.db_url != target.db_url` prevents the catastrophic
+  case of pointing both ends at the same database.
+- The script never issues `psql -c "..."` against the source for any write
+  statement; the only `psql` calls against source are read-only `SELECT count(*)`
+  preflight probes.
+
+### Non-empty-target refusal
+
+Before any restore, the script runs (against the **target** only):
+
+```sql
+SELECT count(*) FROM information_schema.tables
+ WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
+SELECT count(*) FROM auth.users;
+```
+
+If either is non-zero, `die` with a clear message: "target is not empty — Layer 1
+migrates into a fresh instance only. Re-provision the target and re-run."
+
+---
+
+## 7. Manual-Steps Report (the contract of this layer)
+
+Printed to stdout at the end, always. The report is the **authoritative list of
+what the operator must now do by hand**. It is generated from a fixed template
+plus runtime-discovered items (e.g. storage copy failures, missing schemas).
+
+Template (printed verbatim, with runtime substitutions):
+
+```
+================================================================================
+ MANUAL STEPS — complete these by hand. Migration is NOT finished until you do.
+================================================================================
+
+1. AUTH CONFIGURATION (not migrated)
+   - [ ] Review and re-create auth providers in the self-hosted Studio:
+         Dashboard → Authentication → Providers
+   - [ ] Re-create any custom email templates (Dashboard → Auth → Email Templates)
+   - [ ] Re-configure SMTP settings (already in env/supabase.yml — verify)
+   - [ ] Re-create any MFA / SAML / hooks configuration
+
+2. EDGE FUNCTIONS (not migrated)
+   - [ ] List your functions: supabase functions list --project-ref <ref>
+   - [ ] Deploy each: supabase functions deploy <name> --project-ref <self-hosted-ref>
+         (or copy the source and deploy via the self-hosted CLI)
+
+3. CRON JOBS (not migrated)
+   - [ ] Re-create pg_cron jobs: SELECT cron.schedule(...) for each job
+   - [ ] Source list: SELECT * FROM cron.job;
+
+4. WEBHOOKS (not migrated)
+   - [ ] Re-create any database webhooks (Dashboard → Database → Webhooks)
+
+5. STORAGE BUCKET CONFIGURATION (not migrated — objects only)
+   - [ ] Re-create bucket definitions (public/private, file size limits, MIME types)
+   - [ ] Re-create any per-bucket RLS policies
+
+6. CLIENT ENV VARS (operator action)
+   - [ ] Update your application's NEXT_PUBLIC_SUPABASE_URL / VITE_SUPABASE_URL
+         to point at the self-hosted API URL
+   - [ ] Update NEXT_PUBLIC_SUPABASE_ANON_KEY / VITE_SUPABASE_ANON_KEY
+         to the self-hosted anon key (from env/supabase.yml)
+
+7. USERS MUST LOG IN AGAIN
+   - [ ] Notify users that sessions are invalidated; password hashes migrated,
+         so existing passwords still work.
+
+RUNTIME NOTES (discovered during this run):
+- <list of skipped schemas, storage failures, etc. — empty if none>
+================================================================================
+```
+
+---
+
+## 8. Error Handling
+
+- `set -euo pipefail` (same as `setup.sh`).
+- Every phase wrapped in a function; failures call `die` with the phase name +
+  tail of the captured log.
+- No retry, no resume (explicitly out of scope). A failure means starting over.
+- `--dry-run` prints the plan (phases + commands that would run) and exits 0
+  before touching anything.
+
+---
+
+## 9. Testing Strategy
+
+Shell-level tests in `tests/test-migrate.sh`, mirroring `tests/test-setup.sh`'s
+shape (sandbox + stubbed binaries). The test harness stubs `pg_dump`, `pg_restore`,
+`rclone`, and `psql` so tests run without a real Supabase project or database.
+
+Test categories:
+- Config validation (missing file, `changeit` fields, invalid DSN, source==target)
+- Preflight (missing binaries, non-empty target refusal)
+- Dry-run (no side effects, prints plan)
+- Non-interactive (`--yes` with no TTY)
+- Help output
+- Phase execution with stubs (asserts the right commands are invoked)
+- Manual-steps report is always printed
+- Read-only-source invariant (no write command ever issued against source DSN)
+
+---
+
+## 10. File Manifest
+
+| Path | Purpose |
+|---|---|
+| `migrate.sh` | The migration script (root, sibling to `setup.sh`) |
+| `env/migrate.example.yml` | Example config (operator copies to `env/migrate.yml`) |
+| `docs/designs/migration-layer-1.md` | This design canvas |
+| `docs/test-cases/migration-layer-1.md` | Test case document |
+| `tests/test-migrate.sh` | Shell-level test harness |
+| `README.md` | Add a "Migration from Supabase Cloud" section |
+
+---
+
+## 11. Acceptance Criteria Mapping
+
+| Issue criterion | How this design satisfies it |
+|---|---|
+| Test project migrates in one command | `./migrate.sh --config env/migrate.yml --yes` |
+| Application reconnects after env var update | Manual-steps report item 6 + auth users migrated with UUIDs intact |
+| Every unmigrated item in manual-steps report | Section 7 template — fixed + runtime items |
+| Source provably never written to | `pg_dump` (read-only) + `rclone copy` (not sync/move) + preflight `source != target` assertion + no write `psql` against source |
+| Runs with no TTY | `--yes` gates all prompts; colors off when `! [[ -t 1 ]]` |

--- a/docs/designs/migration-layer-1.md
+++ b/docs/designs/migration-layer-1.md
@@ -139,20 +139,19 @@ Phase 0: Preflight
   └─ if --dry-run: print plan and exit 0
 
 Phase 1: Database — schema + data
-  ├─ pg_dump source (full, custom format, includes extensions + roles)
-  │     flags: --format=custom --no-owner --no-privileges --clean --if-exists
-  │     + --section=pre-data --section=post-data --section=data
+  ├─ pg_dump source (per-schema, custom format)
+  │     flags: --format=custom --no-owner --no-privileges --schema=<name>
   │     + --schema=public --schema=auth --schema=storage --schema=_realtime
   │       --schema=graphql_public --schema=extensions --schema=pgsodium
   │       (best-effort: missing schemas are skipped with a warning, not fatal)
-  ├─ stream into pg_restore target
-  │     flags: --no-owner --no-privileges --clean --if-exists
-  │     + --exit-on-error for the pre-data section only
-  └─ on failure: die() with the failing command + tail of the log
+  ├─ pg_restore into target (DSN via --dbname=, archive file as positional)
+  │     flags: --dbname=<target_dsn> --no-owner --no-privileges
+  │            --clean --if-exists --exit-on-error
+  └─ on failure: warn() + add to runtime notes (non-fatal per schema)
 
 Phase 2: Auth users (UUIDs preserved)
   ├─ pg_dump auth.users auth.identities from source (data-only, INSERT copy)
-  ├─ pg_restore into target
+  ├─ pg_restore into target (DSN via --dbname=, archive file as positional)
   └─ NOTE: users must log in again (password hashes migrate, but sessions do not)
 
 Phase 3: Storage objects (rclone copy)
@@ -172,9 +171,9 @@ Phase 4: Manual-steps report
 - `rclone copy` (not `sync`, not `move`) — source is never mutated.
 - A preflight assertion `source.db_url != target.db_url` prevents the catastrophic
   case of pointing both ends at the same database.
-- The script never issues `psql -c "..."` against the source for any write
-  statement; the only `psql` calls against source are read-only `SELECT count(*)`
-  preflight probes.
+- The script never issues `psql` against the source at all — the only `psql`
+  calls are read-only `SELECT count(*)` preflight probes against the **target**
+  (to verify it is empty). The source is touched only by `pg_dump` (read-only).
 
 ### Non-empty-target refusal
 

--- a/docs/test-cases/migration-layer-1.md
+++ b/docs/test-cases/migration-layer-1.md
@@ -1,0 +1,129 @@
+# Test Cases: Migration Script (Layer 1) — `migrate.sh`
+
+Feature: One-command migration of a Supabase Cloud project into a self-hosted
+instance (`migrate.sh` + `env/migrate.example.yml`)
+Issue: #99
+
+## Scope
+
+Layer 1 is the walking skeleton: schema+data, auth users (UUIDs preserved),
+storage objects (copy only), and a manual-steps report. No verification,
+dry-run-only side effects, no resumability, no auth-config import. The script
+is read-only against the source and refuses a non-empty target.
+
+Tests are shell-level (mirroring `tests/test-setup.sh`): they sandbox the
+script and stub `pg_dump`, `pg_restore`, `rclone`, and `psql` so they run
+without a real Supabase project or database. The stubs record the argv they
+received so tests can assert the **read-only-source invariant** (no write
+command is ever issued against the source DSN).
+
+## Test Scenarios
+
+### TC-MIG-001: Missing config file
+- **Given**: no `env/migrate.yml`
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with a clear error pointing to `env/migrate.example.yml`
+
+### TC-MIG-002: Required fields left as "changeit"
+- **Given**: `env/migrate.yml` with `source.project_ref: changeit`
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero, listing every field still set to `changeit`
+
+### TC-MIG-003: Invalid source DSN scheme
+- **Given**: `source.db_url: mysql://user@host/db` (not postgresql://)
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with "must start with postgresql://"
+
+### TC-MIG-004: Source DSN equals target DSN (read-only-source invariant)
+- **Given**: `source.db_url` and `target.db_url` are identical
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with "source and target must not be the same database"
+
+### TC-MIG-005: Missing required binary
+- **Given**: `rclone` not on PATH (PATH scrubbed in sandbox)
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with "required binary not found: rclone"
+
+### TC-MIG-006: Non-empty target refusal (relations present)
+- **Given**: stubbed `psql` returns count > 0 for `public` tables
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with "target is not empty" before any `pg_dump`/`pg_restore` runs
+
+### TC-MIG-007: Non-empty target refusal (auth.users present)
+- **Given**: stubbed `psql` returns count > 0 for `auth.users`
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits non-zero with "target is not empty"
+
+### TC-MIG-008: Dry-run does not modify anything
+- **Given**: valid config + stubbed binaries
+- **When**: `bash migrate.sh --config env/migrate.yml --dry-run --yes`
+- **Then**: exits 0, prints the plan (phases + commands), and no stubbed
+  `pg_dump`/`pg_restore`/`rclone`/`psql` is invoked
+
+### TC-MIG-009: Help output
+- **When**: `bash migrate.sh --help`
+- **Then**: prints usage with all supported flags and exits 0
+
+### TC-MIG-010: Non-interactive execution (no TTY)
+- **Given**: valid config + stubbed binaries + `</dev/null`
+- **When**: `bash migrate.sh --config env/migrate.yml --yes </dev/null`
+- **Then**: completes without blocking on stdin; stubs record expected commands
+
+### TC-MIG-011: Full happy path with stubs
+- **Given**: valid config + stubbed binaries (psql returns 0 for both counts)
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: exits 0, invokes `pg_dump` against source DSN, invokes `pg_restore`
+  against target DSN, invokes `rclone copy` (not sync/move), and prints the
+  manual-steps report
+
+### TC-MIG-012: Manual-steps report is always printed
+- **Given**: any successful run (happy path)
+- **When**: the script completes
+- **Then**: stdout contains the "MANUAL STEPS" header and all 7 numbered sections
+  (auth config, edge functions, cron jobs, webhooks, storage bucket config,
+  client env vars, users must log in again)
+
+### TC-MIG-013: Read-only-source invariant — no write command against source
+- **Given**: full happy path with stubs that log their argv
+- **When**: the script runs
+- **Then**: no stubbed binary is invoked with a write subcommand against the
+  source DSN. Specifically:
+  - `pg_dump` (read-only) is the only binary pointed at the source DSN
+  - `rclone` is invoked with `copy` (not `sync`, not `move`, not `delete`)
+  - `psql` against the source is only ever `SELECT count(*)` (preflight)
+
+### TC-MIG-014: Storage failure is non-fatal + appears in runtime notes
+- **Given**: stubbed `rclone` exits non-zero
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: script warns, continues, and the manual-steps report's "RUNTIME NOTES"
+  section lists the storage copy failure
+
+### TC-MIG-015: Missing optional schema is skipped with warning, not fatal
+- **Given**: stubbed `pg_dump` exits non-zero for one `--schema=` flag
+- **When**: `bash migrate.sh --config env/migrate.yml --yes`
+- **Then**: script warns about the skipped schema, continues with the others,
+  and the skipped schema name appears in RUNTIME NOTES
+
+### TC-MIG-016: env/migrate.example.yml is valid YAML
+- **When**: `env/migrate.example.yml` is parsed
+- **Then**: it is valid YAML with `source`, `target`, `tools` top-level keys
+
+### TC-MIG-017: Unknown flag rejected
+- **When**: `bash migrate.sh --bogus`
+- **Then**: exits non-zero with "Unknown option" (matches `setup.sh` behavior)
+
+### TC-MIG-018: --config is required
+- **Given**: no `--config` flag
+- **When**: `bash migrate.sh --yes`
+- **Then**: exits non-zero with a message telling the user to pass `--config`
+
+### TC-MIG-019: pg_dump uses read-only-compatible flags
+- **Given**: full happy path with stubs
+- **When**: the script runs
+- **Then**: the `pg_dump` invocation includes `--no-owner --no-privileges` and
+  does NOT include any write flag (pg_dump has none, but assert the flag set)
+
+### TC-MIG-020: pg_restore targets the target DSN only
+- **Given**: full happy path with stubs
+- **When**: the script runs
+- **Then**: `pg_restore` is invoked with the target DSN, never the source DSN

--- a/env/migrate.example.yml
+++ b/env/migrate.example.yml
@@ -1,0 +1,65 @@
+# =============================================================================
+# migrate.example.yml — Migration configuration (Layer 1)
+# =============================================================================
+# Copy this file to env/migrate.yml and edit it:
+#   cp env/migrate.example.yml env/migrate.yml
+#   # edit env/migrate.yml, then run:
+#   ./migrate.sh --config env/migrate.yml --yes
+#
+# INVARIANT: this script is READ-ONLY against the source project. It never
+# writes to the source. It refuses to run if source and target point at the
+# same database, and it refuses to run against a non-empty target.
+#
+# Sections:
+#   SOURCE   — The Supabase Cloud project you are migrating FROM.
+#   TARGET   — The self-hosted instance you are migrating INTO.
+#   TOOLS    — Paths to required binaries (defaults resolve via PATH).
+# ============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE — Supabase Cloud project (read-only)
+# ─────────────────────────────────────────────────────────────────────────────
+source:
+  # Project ref — found in the Dashboard URL or Settings → API.
+  project_ref: changeit            # e.g. abcdefghijklmnop
+
+  # Direct Postgres connection string to the Cloud project.
+  # Use the pooler DSN (port 6543 for transaction mode, 5432 for session mode).
+  # The script opens this READ-ONLY (pg_dump never writes).
+  db_url: changeit                 # postgresql://postgres.[ref]:[pwd]@db.[ref].supabase.co:6543/postgres
+
+  # S3-compatible storage endpoint credentials (Supabase Cloud S3 API).
+  # Found in Dashboard → Settings → Storage.
+  storage_endpoint: changeit       # https://[ref].supabase.co/storage/v1
+  storage_access_key: changeit
+  storage_secret_key: changeit
+  storage_region: changeit         # e.g. us-east-1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TARGET — Self-hosted Supabase instance (this repo's stack)
+# ─────────────────────────────────────────────────────────────────────────────
+target:
+  # Self-hosted Postgres DSN. Default matches the local docker-compose service
+  # name + the default password from env/supabase.yml. Adjust to match your
+  # env/supabase.yml postgres_db_pwd if you changed it.
+  db_url: postgresql://postgres:postgres@localhost:5432/postgres
+
+  # Self-hosted storage endpoint (Kong /storage/v1 on the API port).
+  storage_endpoint: http://localhost:8000/storage/v1
+  # These come from env/supabase.yml:
+  #   s3_protocol_access_key_id / s3_protocol_access_key_secret
+  storage_access_key: changeit
+  storage_secret_key: changeit
+  storage_region: us-east-1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TOOLS — Required binaries (defaults resolve via PATH)
+# ─────────────────────────────────────────────────────────────────────────────
+# Override only if a binary is installed outside PATH.
+tools:
+  pg_dump: pg_dump
+  pg_restore: pg_restore
+  rclone: rclone
+  psql: psql

--- a/migrate.sh
+++ b/migrate.sh
@@ -190,6 +190,20 @@ ok "All required binaries found."
 RUNTIME_NOTES=()
 add_note() { RUNTIME_NOTES+=("$1"); }
 
+# ─── Temp files + cleanup ────────────────────────────────────────────────────
+# Single LOG_DIR for all error logs (avoids /tmp collisions on concurrent runs).
+# Temp dump/config files are declared empty here so cleanup() is safe even if
+# the script exits before they are created.
+LOG_DIR="$(mktemp -d -t migrate-logs-XXXXXX)"
+DUMP_FILE=""
+AUTH_DUMP=""
+RCLONE_CONF=""
+cleanup() {
+  rm -f "$DUMP_FILE" "$AUTH_DUMP" "$RCLONE_CONF"
+  rm -rf "$LOG_DIR"
+}
+trap cleanup EXIT
+
 # ─── Dry-run: print plan and exit ─────────────────────────────────────────────
 if [[ $DRY_RUN -eq 1 ]]; then
   log "DRY RUN — no files will be modified, no commands will execute."
@@ -217,10 +231,20 @@ fi
 log "Checking target is empty…"
 
 # Count base tables in public schema (target only — read-only probe).
-tgt_public_tables=$("$PSQL" "$TGT_DB_URL" -tAX \
-  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';" 2>/dev/null || echo "0")
-tgt_auth_users=$("$PSQL" "$TGT_DB_URL" -tAX \
-  -c "SELECT count(*) FROM auth.users;" 2>/dev/null || echo "0")
+# A connection failure to the target must NOT be masked as "empty" — die with
+# the real psql error so the operator fixes the DSN before any restore runs.
+if ! tgt_public_tables=$("$PSQL" "$TGT_DB_URL" -tAX \
+  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';" 2>"$LOG_DIR/psql-public.err"); then
+  die "cannot reach target database (public-tables probe failed).
+  Verify target.db_url is correct and the database is running.
+  psql error: $(cat "$LOG_DIR/psql-public.err")"
+fi
+if ! tgt_auth_users=$("$PSQL" "$TGT_DB_URL" -tAX \
+  -c "SELECT count(*) FROM auth.users;" 2>"$LOG_DIR/psql-auth.err"); then
+  die "cannot reach target database (auth.users probe failed).
+  Verify target.db_url is correct and the database is running.
+  psql error: $(cat "$LOG_DIR/psql-auth.err")"
+fi
 
 reasons=()
 [[ "${tgt_public_tables:-0}" -gt 0 ]] && reasons+=("${tgt_public_tables} base table(s) in schema 'public'")
@@ -240,7 +264,6 @@ log "Phase 1: dumping and restoring schema + data…"
 SCHEMAS=(public auth storage _realtime graphql_public extensions pgsodium)
 
 DUMP_FILE="$(mktemp -t migrate-dump-XXXXXX.dump)"
-trap 'rm -f "$DUMP_FILE"' EXIT
 
 # Build --schema= flags. pg_dump fails if a schema doesn't exist; we dump each
 # schema separately so a missing one is skipped with a warning, not fatal.
@@ -250,20 +273,23 @@ for schema in "${SCHEMAS[@]}"; do
         --format=custom \
         --no-owner --no-privileges \
         --schema="$schema" \
-        --file="$DUMP_FILE" 2>/tmp/migrate-pgdump.err; then
+        --file="$DUMP_FILE" 2>"$LOG_DIR/pgdump-$schema.err"; then
     warn "skipping schema '$schema' (not present in source or dump failed)"
     add_note "Skipped schema '$schema' (not present in source or pg_dump failed)."
     continue
   fi
   log "  restoring schema: $schema"
-  if ! "$PG_RESTORE" "$TGT_DB_URL" \
+  # pg_restore's positional arg is the archive FILE, not a DSN. Pass the target
+  # DSN via --dbname= (which accepts a libpq conninfo URI). This is the fix for
+  # the critical bug where the DSN was passed as the filename positional.
+  if ! "$PG_RESTORE" \
+        --dbname="$TGT_DB_URL" \
         --no-owner --no-privileges \
         --clean --if-exists \
-        --dbname=postgres \
         --exit-on-error \
-        "$DUMP_FILE" 2>/tmp/migrate-pgrestore.err; then
-    warn "restore of schema '$schema' failed — see /tmp/migrate-pgrestore.err"
-    add_note "Restore of schema '$schema' failed. See /tmp/migrate-pgrestore.err."
+        "$DUMP_FILE" 2>"$LOG_DIR/pgrestore-$schema.err"; then
+    warn "restore of schema '$schema' failed — see $LOG_DIR/pgrestore-$schema.err"
+    add_note "Restore of schema '$schema' failed. See $LOG_DIR/pgrestore-$schema.err."
   fi
   rm -f "$DUMP_FILE"
 done
@@ -281,18 +307,19 @@ if "$PG_DUMP" "$SRC_DB_URL" \
       --data-only \
       --table="auth.users" \
       --table="auth.identities" \
-      --file="$AUTH_DUMP" 2>/tmp/migrate-auth-dump.err; then
-  "$PG_RESTORE" "$TGT_DB_URL" \
+      --file="$AUTH_DUMP" 2>"$LOG_DIR/auth-dump.err"; then
+  # pg_restore: DSN via --dbname=, archive file as the sole positional (see Phase 1).
+  "$PG_RESTORE" \
+    --dbname="$TGT_DB_URL" \
     --no-owner --no-privileges \
     --data-only \
-    --dbname=postgres \
     --exit-on-error \
-    "$AUTH_DUMP" 2>/tmp/migrate-auth-restore.err \
-    || { warn "auth.users restore failed — see /tmp/migrate-auth-restore.err"; add_note "auth.users restore failed. See /tmp/migrate-auth-restore.err."; }
+    "$AUTH_DUMP" 2>"$LOG_DIR/auth-restore.err" \
+    || { warn "auth.users restore failed — see $LOG_DIR/auth-restore.err"; add_note "auth.users restore failed. See $LOG_DIR/auth-restore.err."; }
   ok "Phase 2 complete (auth users migrated with UUIDs preserved)."
 else
-  warn "auth.users dump failed — see /tmp/migrate-auth-dump.err"
-  add_note "auth.users dump failed. See /tmp/migrate-auth-dump.err. Users must be re-created manually."
+  warn "auth.users dump failed — see $LOG_DIR/auth-dump.err"
+  add_note "auth.users dump failed. See $LOG_DIR/auth-dump.err. Users must be re-created manually."
 fi
 rm -f "$AUTH_DUMP"
 
@@ -310,7 +337,6 @@ TGT_STORAGE_REGION="$(cfg_get "target.storage_region")"
 
 # Build ephemeral rclone config. rclone reads config from a file via --config.
 RCLONE_CONF="$(mktemp -t migrate-rclone-XXXXXX.conf)"
-trap 'rm -f "$DUMP_FILE" "$AUTH_DUMP" "$RCLONE_CONF"' EXIT
 cat > "$RCLONE_CONF" <<EOF
 [src]
 type = s3
@@ -332,11 +358,11 @@ EOF
 # rclone copy (NOT sync, NOT move) — source is never mutated.
 # --progress=no keeps output TTY-free (runs with no TTY attached).
 if "$RCLONE" --config "$RCLONE_CONF" copy src: tgt: \
-     --progress=no 2>/tmp/migrate-rclone.err; then
+     --progress=no 2>"$LOG_DIR/rclone.err"; then
   ok "Phase 3 complete (storage objects copied)."
 else
-  warn "storage copy failed — see /tmp/migrate-rclone.err (best-effort at this layer)"
-  add_note "Storage copy failed. See /tmp/migrate-rclone.err. Re-run rclone manually after fixing the config."
+  warn "storage copy failed — see $LOG_DIR/rclone.err (best-effort at this layer)"
+  add_note "Storage copy failed. See $LOG_DIR/rclone.err. Re-run rclone manually after fixing the config."
 fi
 
 # ─── Phase 4: Manual-steps report ────────────────────────────────────────────

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+# =============================================================================
+# migrate.sh — Migrate a Supabase Cloud project into a self-hosted instance.
+# =============================================================================
+# Layer 1 walking skeleton: schema+data, auth users (UUIDs preserved), storage
+# objects (copy only), and a manual-steps report. Read-only against the source.
+# Refuses a non-empty target. No resumability — a failure means starting over.
+#
+# Usage:
+#   ./migrate.sh --config env/migrate.yml --yes
+#   ./migrate.sh --config env/migrate.yml --dry-run
+#   ./migrate.sh --help
+#
+# Conventions mirror setup.sh: YAML config, non-interactive by default, flags
+# are verbs only. See docs/designs/migration-layer-1.md for the full design.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_CONFIG="${SCRIPT_DIR}/env/migrate.example.yml"
+
+CONFIG_FILE=""
+DRY_RUN=0
+ASSUME_YES=0
+VERBOSE=0
+
+# ─── Colors (disabled when not a TTY — runs with no TTY attached) ───────────
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+log()     { printf "${BLUE}[migrate]${NC} %s\n" "$*"; }
+ok()      { printf "${GREEN}[ok]${NC} %s\n" "$*"; }
+warn()    { printf "${YELLOW}[warn]${NC} %s\n" "$*" >&2; }
+die()     { printf "${RED}[error]${NC} %s\n" "$*" >&2; exit 1; }
+
+# ─── Help ────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+migrate.sh — Migrate a Supabase Cloud project into a self-hosted instance (Layer 1)
+
+Usage:
+  ./migrate.sh --config <path> [options]
+
+Options:
+  --config <path>   Path to the migration config file (required)
+  --dry-run         Preview the migration plan without modifying anything
+  --yes             Non-interactive (skip confirmation prompts) — for AI/CI
+  -v, --verbose     Verbose output
+  -h, --help        Show this help and exit
+
+Workflow:
+  1. Copy env/migrate.example.yml to env/migrate.yml
+  2. Edit the SOURCE and TARGET sections in env/migrate.yml
+  3. Run: ./migrate.sh --config env/migrate.yml --yes
+
+The script:
+  - Validates the config (required fields, DSN schemes, source != target)
+  - Asserts required binaries are on PATH (pg_dump, pg_restore, rclone, psql)
+  - Refuses to run against a non-empty target
+  - Dumps and restores the database (schema + data, Supabase-managed schemas)
+  - Migrates auth.users and auth.identities with UUIDs preserved
+  - Copies storage objects via rclone (read-only against source)
+  - Prints a manual-steps report listing everything NOT migrated
+
+INVARIANT: read-only against the source project. Always. At every layer.
+EOF
+}
+
+# ─── Argument parsing (verbs only, matches setup.sh style) ───────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)   CONFIG_FILE="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    --yes)      ASSUME_YES=1; shift ;;
+    -v|--verbose) VERBOSE=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "Unknown option: $1 (try --help)" ;;
+  esac
+done
+
+[[ $VERBOSE -eq 1 ]] && set -x
+
+# --config is required
+[[ -n "$CONFIG_FILE" ]] || die "--config is required. Usage: ./migrate.sh --config env/migrate.yml --yes"
+
+# ─── Preflight: config file exists ───────────────────────────────────────────
+[[ -f "$EXAMPLE_CONFIG" ]] || die "env/migrate.example.yml not found in $SCRIPT_DIR"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  die "Config file not found: $CONFIG_FILE
+
+  Copy the example and edit it:
+    cp env/migrate.example.yml env/migrate.yml
+    # edit env/migrate.yml, then re-run:
+    ./migrate.sh --config env/migrate.yml --yes"
+fi
+
+command -v python3 >/dev/null 2>&1 || die "python3 is required (YAML parsing depends on it). Install with: sudo apt install -y python3"
+
+# ─── YAML parsing via python3 (same pattern as setup.sh) ─────────────────────
+# Reads a value from the config. Usage: cfg_get "source.project_ref"
+cfg_get() {
+  python3 - "$CONFIG_FILE" "$1" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+keys = sys.argv[2].split('.')
+node = data
+for k in keys:
+    if isinstance(node, dict) and k in node:
+        node = node[k]
+    else:
+        print("")
+        sys.exit(0)
+if isinstance(node, bool):
+    print("true" if node else "false")
+elif isinstance(node, (list, dict)):
+    print(yaml.dump(node, default_flow_style=False).strip())
+else:
+    print(node if node is not None else "")
+PYEOF
+}
+
+# ─── Config validation ───────────────────────────────────────────────────────
+log "Validating $CONFIG_FILE…"
+
+REQUIRED_FIELDS=(
+  "source.project_ref"
+  "source.db_url"
+  "source.storage_endpoint"
+  "source.storage_access_key"
+  "source.storage_secret_key"
+  "source.storage_region"
+  "target.db_url"
+  "target.storage_endpoint"
+  "target.storage_access_key"
+  "target.storage_secret_key"
+  "target.storage_region"
+)
+
+MISSING=()
+for field in "${REQUIRED_FIELDS[@]}"; do
+  val="$(cfg_get "$field")"
+  if [[ -z "$val" || "$val" == "changeit" ]]; then
+    MISSING+=("$field")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  die "The following fields in $CONFIG_FILE are still set to 'changeit' or empty:
+
+  $(printf '  - %s\n' "${MISSING[@]}")
+
+Edit $CONFIG_FILE and fill in every field under SOURCE and TARGET."
+fi
+
+# Resolve tool paths (defaults via PATH, overridable in config)
+PG_DUMP="$(cfg_get "tools.pg_dump")";    PG_DUMP="${PG_DUMP:-pg_dump}"
+PG_RESTORE="$(cfg_get "tools.pg_restore")"; PG_RESTORE="${PG_RESTORE:-pg_restore}"
+RCLONE="$(cfg_get "tools.rclone")";      RCLONE="${RCLONE:-rclone}"
+PSQL="$(cfg_get "tools.psql")";          PSQL="${PSQL:-psql}"
+
+# DSN scheme validation
+SRC_DB_URL="$(cfg_get "source.db_url")"
+TGT_DB_URL="$(cfg_get "target.db_url")"
+
+[[ "$SRC_DB_URL" == postgresql://* || "$SRC_DB_URL" == postgres://* ]] \
+  || die "source.db_url must start with postgresql:// (got: ${SRC_DB_URL:0:20}…)"
+[[ "$TGT_DB_URL" == postgresql://* || "$TGT_DB_URL" == postgres://* ]] \
+  || die "target.db_url must start with postgresql:// (got: ${TGT_DB_URL:0:20}…)"
+
+# Read-only-source invariant: source != target
+if [[ "$SRC_DB_URL" == "$TGT_DB_URL" ]]; then
+  die "source.db_url and target.db_url must not be the same database.
+  The source project is read-only; migrating a database into itself is refused."
+fi
+
+# ─── Required binaries on PATH ───────────────────────────────────────────────
+log "Checking required binaries…"
+for bin in "$PG_DUMP" "$PG_RESTORE" "$RCLONE" "$PSQL"; do
+  command -v "$bin" >/dev/null 2>&1 || die "required binary not found: $bin"
+done
+ok "All required binaries found."
+
+# Capture runtime notes for the manual-steps report.
+RUNTIME_NOTES=()
+add_note() { RUNTIME_NOTES+=("$1"); }
+
+# ─── Dry-run: print plan and exit ─────────────────────────────────────────────
+if [[ $DRY_RUN -eq 1 ]]; then
+  log "DRY RUN — no files will be modified, no commands will execute."
+  log "Plan:"
+  log "  Phase 1: pg_dump source → pg_restore target (schema + data)"
+  log "    source DSN: ${SRC_DB_URL}"
+  log "    target DSN: ${TGT_DB_URL}"
+  log "    schemas: public auth storage _realtime graphql_public extensions pgsodium (best-effort)"
+  log "  Phase 2: pg_dump auth.users + auth.identities → pg_restore target (UUIDs preserved)"
+  log "  Phase 3: rclone copy source-storage → target-storage (read-only against source)"
+  log "  Phase 4: print manual-steps report"
+  ok "Dry run complete. Re-run without --dry-run to migrate."
+  exit 0
+fi
+
+# ─── Confirmation ─────────────────────────────────────────────────────────────
+if [[ $ASSUME_YES -eq 0 ]]; then
+  printf "About to migrate:\n  source: %s\n  target: %s\n\n" "$SRC_DB_URL" "$TGT_DB_URL"
+  printf "This accepts DOWNTIME. The target will be written to; the source is read-only.\n"
+  read -rp "Proceed? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || die "Aborted by user."
+fi
+
+# ─── Non-empty target refusal ─────────────────────────────────────────────────
+log "Checking target is empty…"
+
+# Count base tables in public schema (target only — read-only probe).
+tgt_public_tables=$("$PSQL" "$TGT_DB_URL" -tAX \
+  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';" 2>/dev/null || echo "0")
+tgt_auth_users=$("$PSQL" "$TGT_DB_URL" -tAX \
+  -c "SELECT count(*) FROM auth.users;" 2>/dev/null || echo "0")
+
+reasons=()
+[[ "${tgt_public_tables:-0}" -gt 0 ]] && reasons+=("${tgt_public_tables} base table(s) in schema 'public'")
+[[ "${tgt_auth_users:-0}" -gt 0 ]]    && reasons+=("${tgt_auth_users} row(s) in auth.users")
+if [[ ${#reasons[@]} -gt 0 ]]; then
+  die "target is not empty — Layer 1 migrates into a fresh instance only.
+  Found: $(printf '%s, ' "${reasons[@]}" | sed 's/, $//').
+  Re-provision the target and re-run."
+fi
+ok "Target is empty."
+
+# ─── Phase 1: Database — schema + data ────────────────────────────────────────
+log "Phase 1: dumping and restoring schema + data…"
+
+# Supabase-managed schemas to carry across. Missing schemas are skipped with a
+# warning (best-effort), not fatal — a Cloud project may not have all of them.
+SCHEMAS=(public auth storage _realtime graphql_public extensions pgsodium)
+
+DUMP_FILE="$(mktemp -t migrate-dump-XXXXXX.dump)"
+trap 'rm -f "$DUMP_FILE"' EXIT
+
+# Build --schema= flags. pg_dump fails if a schema doesn't exist; we dump each
+# schema separately so a missing one is skipped with a warning, not fatal.
+for schema in "${SCHEMAS[@]}"; do
+  log "  dumping schema: $schema"
+  if ! "$PG_DUMP" "$SRC_DB_URL" \
+        --format=custom \
+        --no-owner --no-privileges \
+        --schema="$schema" \
+        --file="$DUMP_FILE" 2>/tmp/migrate-pgdump.err; then
+    warn "skipping schema '$schema' (not present in source or dump failed)"
+    add_note "Skipped schema '$schema' (not present in source or pg_dump failed)."
+    continue
+  fi
+  log "  restoring schema: $schema"
+  if ! "$PG_RESTORE" "$TGT_DB_URL" \
+        --no-owner --no-privileges \
+        --clean --if-exists \
+        --dbname=postgres \
+        --exit-on-error \
+        "$DUMP_FILE" 2>/tmp/migrate-pgrestore.err; then
+    warn "restore of schema '$schema' failed — see /tmp/migrate-pgrestore.err"
+    add_note "Restore of schema '$schema' failed. See /tmp/migrate-pgrestore.err."
+  fi
+  rm -f "$DUMP_FILE"
+done
+ok "Phase 1 complete (schema + data)."
+
+# ─── Phase 2: Auth users (UUIDs preserved) ───────────────────────────────────
+log "Phase 2: migrating auth.users and auth.identities (UUIDs preserved)…"
+
+# Data-only dump of auth.users and auth.identities. UUIDs are preserved because
+# we dump with --data-only (INSERT copy via COPY), not --schema-only.
+AUTH_DUMP="$(mktemp -t migrate-auth-XXXXXX.dump)"
+if "$PG_DUMP" "$SRC_DB_URL" \
+      --format=custom \
+      --no-owner --no-privileges \
+      --data-only \
+      --table="auth.users" \
+      --table="auth.identities" \
+      --file="$AUTH_DUMP" 2>/tmp/migrate-auth-dump.err; then
+  "$PG_RESTORE" "$TGT_DB_URL" \
+    --no-owner --no-privileges \
+    --data-only \
+    --dbname=postgres \
+    --exit-on-error \
+    "$AUTH_DUMP" 2>/tmp/migrate-auth-restore.err \
+    || { warn "auth.users restore failed — see /tmp/migrate-auth-restore.err"; add_note "auth.users restore failed. See /tmp/migrate-auth-restore.err."; }
+  ok "Phase 2 complete (auth users migrated with UUIDs preserved)."
+else
+  warn "auth.users dump failed — see /tmp/migrate-auth-dump.err"
+  add_note "auth.users dump failed. See /tmp/migrate-auth-dump.err. Users must be re-created manually."
+fi
+rm -f "$AUTH_DUMP"
+
+# ─── Phase 3: Storage objects (rclone copy — read-only against source) ───────
+log "Phase 3: copying storage objects via rclone (read-only against source)…"
+
+SRC_STORAGE_ENDPOINT="$(cfg_get "source.storage_endpoint")"
+SRC_STORAGE_AK="$(cfg_get "source.storage_access_key")"
+SRC_STORAGE_SK="$(cfg_get "source.storage_secret_key")"
+SRC_STORAGE_REGION="$(cfg_get "source.storage_region")"
+TGT_STORAGE_ENDPOINT="$(cfg_get "target.storage_endpoint")"
+TGT_STORAGE_AK="$(cfg_get "target.storage_access_key")"
+TGT_STORAGE_SK="$(cfg_get "target.storage_secret_key")"
+TGT_STORAGE_REGION="$(cfg_get "target.storage_region")"
+
+# Build ephemeral rclone config. rclone reads config from a file via --config.
+RCLONE_CONF="$(mktemp -t migrate-rclone-XXXXXX.conf)"
+trap 'rm -f "$DUMP_FILE" "$AUTH_DUMP" "$RCLONE_CONF"' EXIT
+cat > "$RCLONE_CONF" <<EOF
+[src]
+type = s3
+provider = Supabase
+endpoint = ${SRC_STORAGE_ENDPOINT}
+access_key_id = ${SRC_STORAGE_AK}
+secret_access_key = ${SRC_STORAGE_SK}
+region = ${SRC_STORAGE_REGION}
+
+[tgt]
+type = s3
+provider = Supabase
+endpoint = ${TGT_STORAGE_ENDPOINT}
+access_key_id = ${TGT_STORAGE_AK}
+secret_access_key = ${TGT_STORAGE_SK}
+region = ${TGT_STORAGE_REGION}
+EOF
+
+# rclone copy (NOT sync, NOT move) — source is never mutated.
+# --progress=no keeps output TTY-free (runs with no TTY attached).
+if "$RCLONE" --config "$RCLONE_CONF" copy src: tgt: \
+     --progress=no 2>/tmp/migrate-rclone.err; then
+  ok "Phase 3 complete (storage objects copied)."
+else
+  warn "storage copy failed — see /tmp/migrate-rclone.err (best-effort at this layer)"
+  add_note "Storage copy failed. See /tmp/migrate-rclone.err. Re-run rclone manually after fixing the config."
+fi
+
+# ─── Phase 4: Manual-steps report ────────────────────────────────────────────
+print_manual_steps() {
+  cat <<'REPORT'
+================================================================================
+ MANUAL STEPS — complete these by hand. Migration is NOT finished until you do.
+================================================================================
+
+1. AUTH CONFIGURATION (not migrated)
+   - [ ] Review and re-create auth providers in the self-hosted Studio:
+         Dashboard → Authentication → Providers
+   - [ ] Re-create any custom email templates (Dashboard → Auth → Email Templates)
+   - [ ] Re-configure SMTP settings (already in env/supabase.yml — verify)
+   - [ ] Re-create any MFA / SAML / hooks configuration
+
+2. EDGE FUNCTIONS (not migrated)
+   - [ ] List your functions: supabase functions list --project-ref <ref>
+   - [ ] Deploy each: supabase functions deploy <name>
+         (or copy the source and deploy via the self-hosted CLI)
+
+3. CRON JOBS (not migrated)
+   - [ ] Re-create pg_cron jobs: SELECT cron.schedule(...) for each job
+   - [ ] Source list: SELECT * FROM cron.job;
+
+4. WEBHOOKS (not migrated)
+   - [ ] Re-create any database webhooks (Dashboard → Database → Webhooks)
+
+5. STORAGE BUCKET CONFIGURATION (not migrated — objects only)
+   - [ ] Re-create bucket definitions (public/private, file size limits, MIME types)
+   - [ ] Re-create any per-bucket RLS policies
+
+6. CLIENT ENV VARS (operator action)
+   - [ ] Update your application's NEXT_PUBLIC_SUPABASE_URL / VITE_SUPABASE_URL
+         to point at the self-hosted API URL
+   - [ ] Update NEXT_PUBLIC_SUPABASE_ANON_KEY / VITE_SUPABASE_ANON_KEY
+         to the self-hosted anon key (from env/supabase.yml)
+
+7. USERS MUST LOG IN AGAIN
+   - [ ] Notify users that sessions are invalidated; password hashes migrated,
+         so existing passwords still work.
+
+RUNTIME NOTES (discovered during this run):
+REPORT
+  if [[ ${#RUNTIME_NOTES[@]} -eq 0 ]]; then
+    printf -- "- (none)\n"
+  else
+    for note in "${RUNTIME_NOTES[@]}"; do
+      printf -- "- %s\n" "$note"
+    done
+  fi
+  printf '================================================================================\n'
+}
+
+log "Phase 4: printing manual-steps report…"
+print_manual_steps
+ok "Migration complete. Complete the manual steps above to finish."

--- a/tests/test-migrate.sh
+++ b/tests/test-migrate.sh
@@ -1,0 +1,398 @@
+#!/bin/bash
+# test-migrate.sh — Tests for the migration script (migrate.sh, Layer 1)
+# Run: bash tests/test-migrate.sh
+# Shell-level tests that validate migrate.sh behavior with stubbed binaries
+# (pg_dump, pg_restore, rclone, psql) so they run without a real Supabase
+# project or database. Stubs log their argv so tests can assert the
+# read-only-source invariant.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE="$SCRIPT_DIR/.."
+MIGRATE="$WORKTREE/migrate.sh"
+EXAMPLE="$WORKTREE/env/migrate.example.yml"
+
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { printf "  \033[0;32mPASS\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+fail() { printf "  \033[0;31mFAIL\033[0m %s\n" "$1"; FAIL=$((FAIL+1)); }
+
+# ─── Sandbox builder ─────────────────────────────────────────────────────────
+# Creates a sandbox dir with migrate.sh, env/migrate.example.yml, and a
+# stub-bin directory populated with stubbed pg_dump/pg_restore/rclone/psql.
+# Stubs log their argv to $SANDBOX/stub-bin/<name>.calls and behave per the
+# env vars the test sets (e.g. STUB_PSQL_PUBLIC_TABLES=5).
+make_sandbox() {
+  local name="$1"
+  local d="$TMPDIR_BASE/$name"
+  mkdir -p "$d/env" "$d/stub-bin"
+  cp "$MIGRATE" "$d/migrate.sh"
+  cp "$EXAMPLE" "$d/env/migrate.example.yml"
+  chmod +x "$d/migrate.sh"
+
+  # Stub each binary. Each stub appends its argv (one line per arg, NUL-separated
+  # for safety) to its .calls file, then behaves per env vars.
+  for bin in pg_dump pg_restore rclone psql; do
+    cat > "$d/stub-bin/$bin" <<STUB
+#!/bin/bash
+# stub for $bin — logs argv, behaves per env vars
+{
+  printf 'CALL %s\n' "$bin"
+  for a in "\$@"; do printf '  ARG %s\n' "\$a"; done
+} >> "$d/stub-bin/$bin.calls"
+case "$bin" in
+  psql)
+    # psql is called with -c "SELECT count(*) ...". Inspect the query to decide.
+    query="\$(printf '%s ' "\$@" | grep -oE 'SELECT count\(\*\) FROM [a-z._]+')"
+    case "\$query" in
+      *"information_schema.tables"*)
+        echo "\${STUB_PSQL_PUBLIC_TABLES:-0}"
+        ;;
+      *"auth.users"*)
+        echo "\${STUB_PSQL_AUTH_USERS:-0}"
+        ;;
+      *)
+        echo "0"
+        ;;
+    esac
+    ;;
+  pg_dump)
+    # pg_dump succeeds unless STUB_PGDUMP_FAIL_SCHEMA is set to a schema name
+    # present in argv.
+    for a in "\$@"; do
+      case "\$a" in
+        --schema=*)
+          schema="\${a#--schema=}"
+          if [[ "\${STUB_PGDUMP_FAIL_SCHEMA:-}" == "\$schema" ]]; then
+            echo "STUB_PGDUMP_FAIL: \$schema" >&2
+            exit 1
+          fi
+          ;;
+      esac
+    done
+    exit 0
+    ;;
+  pg_restore)
+    [[ "\${STUB_PGRESTORE_FAIL:-0}" == "1" ]] && exit 1
+    exit 0
+    ;;
+  rclone)
+    [[ "\${STUB_RCLONE_FAIL:-0}" == "1" ]] && exit 1
+    exit 0
+    ;;
+esac
+STUB
+    chmod +x "$d/stub-bin/$bin"
+  done
+
+  echo "$d"
+}
+
+# Run migrate in sandbox; sets OUT and RC variables in caller scope.
+run_migrate_rc() {
+  local dir="$1"; shift
+  # Put stub-bin first on PATH so the stubs shadow any real binaries.
+  OUT="$( cd "$dir" && PATH="$dir/stub-bin:$PATH" bash migrate.sh "$@" 2>&1 )" && RC=0 || RC=$?
+}
+
+# Fill all required fields in a config.yml with valid test values.
+fill_required() {
+  local c="$1/env/migrate.yml"
+  sed -i 's|project_ref: changeit|project_ref: testprojref12345|' "$c"
+  sed -i 's|db_url: changeit.*# postgresql://postgres.\[ref\]:\[pwd\]@db.\[ref\].supabase.co:6543/postgres|db_url: postgresql://postgres.testprojref12345:pwd@db.testprojref12345.supabase.co:6543/postgres|' "$c"
+  sed -i 's|storage_endpoint: changeit.*# https://\[ref\].supabase.co/storage/v1|storage_endpoint: https://testprojref12345.supabase.co/storage/v1|' "$c"
+  sed -i 's|storage_access_key: changeit|storage_access_key: srcak12345|' "$c"
+  sed -i 's|storage_secret_key: changeit|storage_secret_key: srcsk12345|' "$c"
+  sed -i 's|storage_region: changeit.*# e.g. us-east-1|storage_region: us-east-1|' "$c"
+  # target defaults are fine except the changeit access/secret keys
+  sed -i 's|storage_access_key: changeit.*# from env/supabase.yml|storage_access_key: tgtak12345|' "$c"
+  sed -i 's|storage_secret_key: changeit.*# from env/supabase.yml|storage_secret_key: tgtsk12345|' "$c"
+}
+
+# ─── TC-MIG-001: Missing config file ─────────────────────────────────────────
+echo "TC-MIG-001: missing config file"
+d="$(make_sandbox tc001)"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "Config file not found"; then
+  ok "exits non-zero with clear message"
+else
+  fail "expected non-zero exit + 'Config file not found' (got rc=$RC)"
+fi
+
+# ─── TC-MIG-002: Required fields left as changeit ─────────────────────────────
+echo "TC-MIG-002: required fields left as changeit"
+d="$(make_sandbox tc002)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "changeit"; then
+  ok "exits non-zero listing changeit fields"
+else
+  fail "expected non-zero exit listing changeit fields (got rc=$RC)"
+fi
+
+# ─── TC-MIG-003: Invalid source DSN scheme ────────────────────────────────────
+echo "TC-MIG-003: invalid source DSN scheme"
+d="$(make_sandbox tc003)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+sed -i 's|db_url: postgresql://postgres.testprojref12345:pwd@db.testprojref12345.supabase.co:6543/postgres|db_url: mysql://user@host/db|' "$d/env/migrate.yml"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "must start with postgresql://"; then
+  ok "exits non-zero on invalid DSN scheme"
+else
+  fail "expected non-zero exit on invalid DSN scheme (got rc=$RC)"
+fi
+
+# ─── TC-MIG-004: Source DSN equals target DSN ─────────────────────────────────
+echo "TC-MIG-004: source DSN equals target DSN"
+d="$(make_sandbox tc004)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+# Make target equal source
+sed -i 's|db_url: postgresql://postgres:postgres@localhost:5432/postgres|db_url: postgresql://postgres.testprojref12345:pwd@db.testprojref12345.supabase.co:6543/postgres|' "$d/env/migrate.yml"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "must not be the same database"; then
+  ok "exits non-zero when source == target"
+else
+  fail "expected non-zero exit on source==target (got rc=$RC)"
+fi
+
+# ─── TC-MIG-005: Missing required binary ──────────────────────────────────────
+echo "TC-MIG-005: missing required binary (rclone)"
+d="$(make_sandbox tc005)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+# Remove the rclone stub so it's not on PATH
+rm "$d/stub-bin/rclone"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "required binary not found: rclone"; then
+  ok "exits non-zero on missing rclone"
+else
+  fail "expected non-zero exit on missing rclone (got rc=$RC)"
+fi
+
+# ─── TC-MIG-006: Non-empty target refusal (relations present) ─────────────────
+echo "TC-MIG-006: non-empty target refusal (public tables)"
+d="$(make_sandbox tc006)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+STUB_PSQL_PUBLIC_TABLES=5 run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "target is not empty"; then
+  ok "exits non-zero on non-empty target (public tables)"
+else
+  fail "expected non-zero exit on non-empty target (got rc=$RC)"
+fi
+
+# ─── TC-MIG-007: Non-empty target refusal (auth.users present) ─────────────────
+echo "TC-MIG-007: non-empty target refusal (auth.users)"
+d="$(make_sandbox tc007)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+STUB_PSQL_AUTH_USERS=3 run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "target is not empty"; then
+  ok "exits non-zero on non-empty target (auth.users)"
+else
+  fail "expected non-zero exit on non-empty target (auth.users) (got rc=$RC)"
+fi
+
+# ─── TC-MIG-008: Dry-run does not modify anything ─────────────────────────────
+echo "TC-MIG-008: dry-run does not invoke any binary"
+d="$(make_sandbox tc008)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --dry-run --yes
+no_calls=true
+for bin in pg_dump pg_restore rclone psql; do
+  if [[ -f "$d/stub-bin/$bin.calls" ]]; then
+    no_calls=false
+    break
+  fi
+done
+if [[ $RC -eq 0 ]] && $no_calls; then
+  ok "dry-run exits 0 and invokes no stubbed binary"
+else
+  fail "dry-run invoked a binary or exited non-zero (rc=$RC)"
+fi
+
+# ─── TC-MIG-009: Help output ──────────────────────────────────────────────────
+echo "TC-MIG-009: help output"
+d="$(make_sandbox tc009)"
+run_migrate_rc "$d" --help
+if [[ $RC -eq 0 ]] && echo "$OUT" | grep -qi "Usage"; then
+  ok "prints usage and exits 0"
+else
+  fail "expected exit 0 with Usage (got rc=$RC)"
+fi
+
+# ─── TC-MIG-010: Non-interactive execution (no TTY) ───────────────────────────
+echo "TC-MIG-010: non-interactive (--yes) execution with no TTY"
+d="$(make_sandbox tc010)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+OUT="$( cd "$d" && PATH="$d/stub-bin:$PATH" bash migrate.sh --config "$d/env/migrate.yml" --yes </dev/null 2>&1 )" && RC=0 || RC=$?
+if [[ $RC -eq 0 ]]; then
+  ok "completes non-interactively with --yes and no TTY"
+else
+  fail "blocked or failed with --yes (rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-MIG-011: Full happy path with stubs ───────────────────────────────────
+echo "TC-MIG-011: full happy path with stubs"
+d="$(make_sandbox tc011)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -eq 0 ]] \
+  && [[ -f "$d/stub-bin/pg_dump.calls" ]] \
+  && [[ -f "$d/stub-bin/pg_restore.calls" ]] \
+  && [[ -f "$d/stub-bin/rclone.calls" ]]; then
+  ok "happy path invokes pg_dump, pg_restore, rclone"
+else
+  fail "happy path did not invoke all expected binaries (rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-MIG-012: Manual-steps report is always printed ────────────────────────
+echo "TC-MIG-012: manual-steps report is always printed"
+# Reuse tc011 output
+if echo "$OUT" | grep -q "MANUAL STEPS" \
+  && echo "$OUT" | grep -q "AUTH CONFIGURATION" \
+  && echo "$OUT" | grep -q "EDGE FUNCTIONS" \
+  && echo "$OUT" | grep -q "CRON JOBS" \
+  && echo "$OUT" | grep -q "WEBHOOKS" \
+  && echo "$OUT" | grep -q "STORAGE BUCKET CONFIGURATION" \
+  && echo "$OUT" | grep -q "CLIENT ENV VARS" \
+  && echo "$OUT" | grep -q "USERS MUST LOG IN AGAIN"; then
+  ok "manual-steps report contains all 7 sections"
+else
+  fail "manual-steps report missing sections"
+fi
+
+# ─── TC-MIG-013: Read-only-source invariant ───────────────────────────────────
+echo "TC-MIG-013: read-only-source invariant (no write command against source)"
+d="$(make_sandbox tc013)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+# Assert: pg_dump is the only binary pointed at the source DSN
+src_dsn="db.testprojref12345.supabase.co"
+violations=0
+# pg_restore must never reference the source DSN
+if [[ -f "$d/stub-bin/pg_restore.calls" ]] && grep -q "$src_dsn" "$d/stub-bin/pg_restore.calls"; then
+  violations=$((violations+1))
+fi
+# rclone must use copy, not sync/move/delete
+if [[ -f "$d/stub-bin/rclone.calls" ]]; then
+  if ! grep -q "ARG copy" "$d/stub-bin/rclone.calls" \
+     || grep -qE "ARG (sync|move|delete|purge|rmdir)" "$d/stub-bin/rclone.calls"; then
+    violations=$((violations+1))
+  fi
+else
+  violations=$((violations+1))  # rclone wasn't called at all
+fi
+# psql against source: only SELECT count(*) (preflight). But psql is only
+# called against the target in our implementation, so source DSN should never
+# appear in psql.calls.
+if [[ -f "$d/stub-bin/psql.calls" ]] && grep -q "$src_dsn" "$d/stub-bin/psql.calls"; then
+  violations=$((violations+1))
+fi
+if [[ $violations -eq 0 ]]; then
+  ok "no write command issued against source DSN"
+else
+  fail "read-only-source invariant violated ($violations violation(s))"
+fi
+
+# ─── TC-MIG-014: Storage failure is non-fatal + appears in runtime notes ──────
+echo "TC-MIG-014: storage failure is non-fatal + in runtime notes"
+d="$(make_sandbox tc014)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+STUB_RCLONE_FAIL=1 run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -eq 0 ]] && echo "$OUT" | grep -qi "storage copy failed"; then
+  ok "storage failure is non-fatal and reported"
+else
+  fail "storage failure should be non-fatal (got rc=$RC)"
+fi
+
+# ─── TC-MIG-015: Missing optional schema is skipped with warning ───────────────
+echo "TC-MIG-015: missing optional schema skipped with warning"
+d="$(make_sandbox tc015)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+STUB_PGDUMP_FAIL_SCHEMA=pgsodium run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ $RC -eq 0 ]] && echo "$OUT" | grep -qi "skipping schema 'pgsodium'"; then
+  ok "missing schema skipped with warning, not fatal"
+else
+  fail "missing schema should be skipped, not fatal (got rc=$RC)"
+  echo "$OUT" | tail -20
+fi
+
+# ─── TC-MIG-016: env/migrate.example.yml is valid YAML ────────────────────────
+echo "TC-MIG-016: env/migrate.example.yml is valid YAML"
+if python3 -c "import yaml; d=yaml.safe_load(open('$EXAMPLE')); \
+  assert set(['source','target','tools']).issubset(d.keys())" 2>/dev/null; then
+  ok "valid YAML with expected top-level keys"
+else
+  fail "env/migrate.example.yml is not valid YAML or missing top-level keys"
+fi
+
+# ─── TC-MIG-017: Unknown flag rejected ────────────────────────────────────────
+echo "TC-MIG-017: unknown flag rejected"
+d="$(make_sandbox tc017)"
+run_migrate_rc "$d" --bogus
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi "Unknown option"; then
+  ok "exits non-zero on unknown flag"
+else
+  fail "expected non-zero exit on unknown flag (got rc=$RC)"
+fi
+
+# ─── TC-MIG-018: --config is required ──────────────────────────────────────────
+echo "TC-MIG-018: --config is required"
+d="$(make_sandbox tc018)"
+run_migrate_rc "$d" --yes
+if [[ $RC -ne 0 ]] && echo "$OUT" | grep -qi -- "--config is required"; then
+  ok "exits non-zero when --config missing"
+else
+  fail "expected non-zero exit when --config missing (got rc=$RC)"
+fi
+
+# ─── TC-MIG-019: pg_dump uses read-only-compatible flags ──────────────────────
+echo "TC-MIG-019: pg_dump uses read-only-compatible flags"
+d="$(make_sandbox tc019)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+if [[ -f "$d/stub-bin/pg_dump.calls" ]] \
+  && grep -q "ARG --no-owner" "$d/stub-bin/pg_dump.calls" \
+  && grep -q "ARG --no-privileges" "$d/stub-bin/pg_dump.calls"; then
+  ok "pg_dump invoked with --no-owner --no-privileges"
+else
+  fail "pg_dump missing --no-owner/--no-privileges flags"
+fi
+
+# ─── TC-MIG-020: pg_restore targets the target DSN only ───────────────────────
+echo "TC-MIG-020: pg_restore targets the target DSN only"
+d="$(make_sandbox tc020)"
+cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
+fill_required "$d"
+run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
+tgt_dsn="localhost:5432"
+src_dsn="db.testprojref12345.supabase.co"
+if [[ -f "$d/stub-bin/pg_restore.calls" ]] \
+  && grep -q "$tgt_dsn" "$d/stub-bin/pg_restore.calls" \
+  && ! grep -q "$src_dsn" "$d/stub-bin/pg_restore.calls"; then
+  ok "pg_restore targets target DSN, never source"
+else
+  fail "pg_restore DSN targeting wrong"
+fi
+
+# ─── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/test-migrate.sh
+++ b/tests/test-migrate.sh
@@ -377,19 +377,22 @@ else
 fi
 
 # ─── TC-MIG-020: pg_restore targets the target DSN only ───────────────────────
-echo "TC-MIG-020: pg_restore targets the target DSN only"
+echo "TC-MIG-020: pg_restore targets the target DSN only (via --dbname=)"
 d="$(make_sandbox tc020)"
 cp "$d/env/migrate.example.yml" "$d/env/migrate.yml"
 fill_required "$d"
 run_migrate_rc "$d" --config "$d/env/migrate.yml" --yes
 tgt_dsn="localhost:5432"
 src_dsn="db.testprojref12345.supabase.co"
+# Strengthened per review (H1): assert the DSN is passed via --dbname= (the
+# correct pg_restore connection option), NOT as a bare positional filename.
+# pg_restore's positional arg is the archive FILE; the DSN must go via --dbname=.
 if [[ -f "$d/stub-bin/pg_restore.calls" ]] \
-  && grep -q "$tgt_dsn" "$d/stub-bin/pg_restore.calls" \
+  && grep -q "ARG --dbname=postgresql://postgres:postgres@${tgt_dsn}/postgres" "$d/stub-bin/pg_restore.calls" \
   && ! grep -q "$src_dsn" "$d/stub-bin/pg_restore.calls"; then
-  ok "pg_restore targets target DSN, never source"
+  ok "pg_restore targets target DSN via --dbname=, never source"
 else
-  fail "pg_restore DSN targeting wrong"
+  fail "pg_restore DSN not passed via --dbname= or targets source"
 fi
 
 # ─── Summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `migrate.sh` — a one-command migration of a Supabase Cloud project into a self-hosted instance (Layer 1 walking skeleton).
- Migrates schema + data (per-schema best-effort), `auth.users` + `auth.identities` with UUIDs preserved, and storage objects via `rclone copy` (read-only against source).
- Prints a manual-steps report listing everything NOT migrated (auth config, Edge Functions, cron jobs, webhooks, storage bucket config, client env vars, users must log in again).

## Design

- [x] Design canvas created (`docs/designs/migration-layer-1.md`)
- [x] Design approved (autonomous mode — no interactive gate)

## Test Plan

- [x] Test cases documented (`docs/test-cases/migration-layer-1.md`)
- [x] Build passes (N/A — shell project, no build step)
- [x] Unit tests pass (`bash tests/test-migrate.sh` → 20/20 pass)
- [ ] CI checks pass
- [x] Code simplification review passed (manual — no code-simplifier plugin)
- [x] PR review agent review passed (manual review of full diff — no pr-review-toolkit plugin)
- [ ] Reviewer bot findings addressed (REVIEW_BOTS empty — skipped)
- [ ] E2E tests pass (N/A — shell-level tests are the verification layer for this script)

## Checklist

- [x] New unit tests written for new functionality (`tests/test-migrate.sh`, 20 tests)
- [x] E2E test cases updated if needed (N/A)
- [x] Documentation updated (README "Migration from Supabase Cloud" section)

## Invariants enforced

- **Read-only against the source.** `pg_dump` (inherently read-only) + `rclone copy` (not `sync`/`move`) + preflight `source != target` assertion + no write `psql` against source. Verified by TC-MIG-013.
- **Refuses a non-empty target.** Preflight counts `public` tables + `auth.users` rows. Verified by TC-MIG-006/007.
- **Runs with no TTY.** `--yes` gates all prompts; colors auto-disable when `! [[ -t 1 ]]`. Verified by TC-MIG-010.
- **No resumability.** A failure means starting over (explicitly out of scope at Layer 1).

Closes #99
