### PR TITLE
fix(migrate): dynamic schema discovery + single dump/restore fixes triggers and silent failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,32 @@ When adding a new variable that users should configure in `config.yml`:
 - `cfg_get "path.to.key"` — reads from `config.yml` via embedded Python YAML parser
 - `cfg_bool "path.to.key"` — returns 0 if `true`, 1 otherwise
 - `set_env_var "key" "value"` — writes `key: value` to `env/supabase.yml` via `sed -i`
+
+## Migration Script (`migrate.sh`)
+
+Migrates a Supabase Cloud project into a self-hosted instance. Lives at `migrate.sh` with config at `env/migrate.yml` (copy of `env/migrate.example.yml`).
+
+### Architecture
+Four phases run sequentially:
+1. **DB dump+restore** — probes all schemas from source, dumps them in a single `pg_dump`, restores in a single `pg_restore`
+2. **Auth users** — data-only dump of `auth.users` + `auth.identities` (preserves UUIDs)
+3. **Storage objects** — `rclone copy` from source S3 to target S3 (best-effort)
+4. **Manual steps report** — prints checklist for post-migration tasks
+
+### Key Difficulty: Cross-Schema Dependencies (Triggers)
+**Problem:** The original per-schema loop (`for schema in ...; do pg_dump --schema=$s; pg_restore; done`) dumped/restored schemas one at a time. Triggers on `public` tables referencing `auth.*` functions failed because `auth` wasn't restored yet when `public` ran. The `--exit-on-error` flag caused those trigger failures to abort the schema restore, so triggers were silently lost.
+
+**Fix:** Replace per-schema loop with a single `pg_dump` (all `--schema=` flags) followed by a single `pg_restore`. pg_dump resolves inter-schema dependency ordering internally, so triggers are created in the correct order. Removed `--exit-on-error` (harmless "already exists" DDL errors) and `--clean --if-exists` (target is fresh, cascade-drop not needed).
+
+### Key Difficulty: Schema Discovery
+**Problem:** The original script hardcoded a schema list (`SCHEMAS=(public auth storage ...)`). This missed custom schemas like `private`, `supabase_migrations`, and required manual updates when new schemas were added.
+
+**Fix:** Probe `information_schema.schemata` dynamically, excluding only Postgres built-in schemas (`pg_catalog`, `information_schema`, `pg_toast`) and temporary schemas (`pg_temp_%`, `pg_toast_temp_%`). All remaining schemas (user + Supabase system) are dumped — Supabase system schema DDL produces harmless "already exists" errors, but their data (auth users, storage metadata, etc.) is migrated.
+
+### Key Difficulty: Temporary Cloud Schemas
+**Problem:** Supabase Cloud Postgres creates ephemeral `pg_temp_N` and `pg_toast_temp_N` schemas for connection pooling. These have reserved `pg_` prefix names that fail on restore with "unacceptable schema name".
+
+**Fix:** Added `NOT LIKE 'pg\_temp\_%'` and `NOT LIKE 'pg\_toast\_temp\_%'` to the schema probe query.
+
+### Key Requirement: supabase_admin User
+The target `db_url` must use `supabase_admin` (superuser), not `postgres`. Only `supabase_admin` has the privileges to restore DDL in the `auth` and `storage` schemas. The `migrate.example.yml` now documents this requirement and provides the correct connection string format.

--- a/env/migrate.example.yml
+++ b/env/migrate.example.yml
@@ -1,14 +1,17 @@
 # =============================================================================
-# migrate.example.yml — Migration configuration (Layer 1)
+# migrate.example.yml — Migration configuration
 # =============================================================================
 # Copy this file to env/migrate.yml and edit it:
 #   cp env/migrate.example.yml env/migrate.yml
 #   # edit env/migrate.yml, then run:
 #   ./migrate.sh --config env/migrate.yml --yes
 #
-# INVARIANT: this script is READ-ONLY against the source project. It never
-# writes to the source. It refuses to run if source and target point at the
-# same database, and it refuses to run against a non-empty target.
+# IMPORTANT: target.db_url MUST use supabase_admin (superuser that owns
+# auth/storage schemas). The default postgres user lacks the privileges to
+# restore auth/storage DDL.
+#
+# INVARIANT: the script is READ-ONLY against the source project. It never
+# writes to the source.
 #
 # Sections:
 #   SOURCE   — The Supabase Cloud project you are migrating FROM.
@@ -25,39 +28,39 @@ source:
 
   # Direct Postgres connection string to the Cloud project.
   # Use the pooler DSN (port 6543 for transaction mode, 5432 for session mode).
-  # The script opens this READ-ONLY (pg_dump never writes).
   db_url: changeit                 # postgresql://postgres.[ref]:[pwd]@db.[ref].supabase.co:6543/postgres
 
   # S3-compatible storage endpoint credentials (Supabase Cloud S3 API).
-  # Found in Dashboard → Settings → Storage.
-  storage_endpoint: changeit       # https://[ref].supabase.co/storage/v1
+  storage_endpoint: changeit       # https://[ref].storage.supabase.co/storage/v1/s3
   storage_access_key: changeit
   storage_secret_key: changeit
   storage_region: changeit         # e.g. us-east-1
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# TARGET — Self-hosted Supabase instance (this repo's stack)
+# TARGET — Self-hosted Supabase instance
 # ─────────────────────────────────────────────────────────────────────────────
 target:
-  # Self-hosted Postgres DSN. Default matches the local docker-compose service
-  # name + the default password from env/supabase.yml. Adjust to match your
-  # env/supabase.yml postgres_db_pwd if you changed it.
-  db_url: postgresql://postgres:postgres@localhost:5432/postgres
+  # IMPORTANT: Connect as supabase_admin (superuser), NOT postgres.
+  # The supabase_admin password is in your Supabase .env file under
+  # SUPABASE_ADMIN_PASSWORD (or SUPABASE_AUTH_EXTERNAL_SUPABASE_ADMIN_PASSWORD).
+  #
+  # For a local Docker instance:
+  #   db_url: postgresql://supabase_admin:<password>@localhost:5432/postgres
+  db_url: changeit
 
   # Self-hosted storage endpoint (Kong /storage/v1 on the API port).
-  storage_endpoint: http://localhost:8000/storage/v1
+  storage_endpoint: http://localhost:8000/storage/v1/s3
   # These come from env/supabase.yml:
   #   s3_protocol_access_key_id / s3_protocol_access_key_secret
   storage_access_key: changeit
   storage_secret_key: changeit
-  storage_region: us-east-1
+  storage_region: local
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TOOLS — Required binaries (defaults resolve via PATH)
 # ─────────────────────────────────────────────────────────────────────────────
-# Override only if a binary is installed outside PATH.
 tools:
   pg_dump: pg_dump
   pg_restore: pg_restore

--- a/migrate.sh
+++ b/migrate.sh
@@ -211,7 +211,7 @@ if [[ $DRY_RUN -eq 1 ]]; then
   log "  Phase 1: pg_dump source → pg_restore target (schema + data)"
   log "    source DSN: ${SRC_DB_URL}"
   log "    target DSN: ${TGT_DB_URL}"
-  log "    schemas: public auth storage _realtime graphql_public extensions pgsodium (best-effort)"
+  log "    schemas: auto-discovered (all non-system schemas)"
   log "  Phase 2: pg_dump auth.users + auth.identities → pg_restore target (UUIDs preserved)"
   log "  Phase 3: rclone copy source-storage → target-storage (read-only against source)"
   log "  Phase 4: print manual-steps report"
@@ -259,40 +259,40 @@ ok "Target is empty."
 # ─── Phase 1: Database — schema + data ────────────────────────────────────────
 log "Phase 1: dumping and restoring schema + data…"
 
-# Supabase-managed schemas to carry across. Missing schemas are skipped with a
-# warning (best-effort), not fatal — a Cloud project may not have all of them.
-SCHEMAS=(public auth storage _realtime graphql_public extensions pgsodium)
+# Probe source for all schemas, excluding only Postgres built-in + temporary
+# system schemas (pg_temp_N, pg_toast_temp_N). Supabase system schemas like
+# auth, storage, realtime, extensions, etc. ARE included — their DDL produces
+# harmless "already exists" errors on the target, but their data comes across.
+log "  probing source schemas…"
+source_schemas=$("$PSQL" "$SRC_DB_URL" -tAX \
+  -c "SELECT schema_name FROM information_schema.schemata
+      WHERE schema_name NOT IN ('pg_catalog','information_schema','pg_toast')
+        AND schema_name NOT LIKE 'pg\_temp\_%'
+        AND schema_name NOT LIKE 'pg\_toast\_temp\_%'
+      ORDER BY schema_name;" 2>"$LOG_DIR/probe.err") \
+  || die "cannot reach source database (probe failed)."
+
+SCHEMA_FLAGS=()
+while IFS= read -r s; do
+  [[ -n "$s" ]] && SCHEMA_FLAGS+=(--schema="$s")
+done <<< "$source_schemas"
+
+[[ ${#SCHEMA_FLAGS[@]} -eq 0 ]] && die "no schemas found on source — nothing to migrate."
+log "  schemas to migrate: ${SCHEMA_FLAGS[*]}"
 
 DUMP_FILE="$(mktemp -t migrate-dump-XXXXXX.dump)"
+log "  dumping database…"
+"$PG_DUMP" "$SRC_DB_URL" --format=custom --no-owner --no-privileges \
+  "${SCHEMA_FLAGS[@]}" --file="$DUMP_FILE" 2>"$LOG_DIR/dump.err" \
+  || die "pg_dump failed. See $LOG_DIR/dump.err."
 
-# Build --schema= flags. pg_dump fails if a schema doesn't exist; we dump each
-# schema separately so a missing one is skipped with a warning, not fatal.
-for schema in "${SCHEMAS[@]}"; do
-  log "  dumping schema: $schema"
-  if ! "$PG_DUMP" "$SRC_DB_URL" \
-        --format=custom \
-        --no-owner --no-privileges \
-        --schema="$schema" \
-        --file="$DUMP_FILE" 2>"$LOG_DIR/pgdump-$schema.err"; then
-    warn "skipping schema '$schema' (not present in source or dump failed)"
-    add_note "Skipped schema '$schema' (not present in source or pg_dump failed)."
-    continue
-  fi
-  log "  restoring schema: $schema"
-  # pg_restore's positional arg is the archive FILE, not a DSN. Pass the target
-  # DSN via --dbname= (which accepts a libpq conninfo URI). This is the fix for
-  # the critical bug where the DSN was passed as the filename positional.
-  if ! "$PG_RESTORE" \
-        --dbname="$TGT_DB_URL" \
-        --no-owner --no-privileges \
-        --clean --if-exists \
-        --exit-on-error \
-        "$DUMP_FILE" 2>"$LOG_DIR/pgrestore-$schema.err"; then
-    warn "restore of schema '$schema' failed — see $LOG_DIR/pgrestore-$schema.err"
-    add_note "Restore of schema '$schema' failed. See $LOG_DIR/pgrestore-$schema.err."
-  fi
-  rm -f "$DUMP_FILE"
-done
+log "  restoring all schemas…"
+if ! "$PG_RESTORE" --dbname="$TGT_DB_URL" --no-owner --no-privileges \
+     "$DUMP_FILE" 2>"$LOG_DIR/restore.err"; then
+  warn "restore had errors — see $LOG_DIR/restore.err"
+  add_note "Restore had errors. See $LOG_DIR/restore.err."
+fi
+rm -f "$DUMP_FILE"
 ok "Phase 1 complete (schema + data)."
 
 # ─── Phase 2: Auth users (UUIDs preserved) ───────────────────────────────────


### PR DESCRIPTION
## Description

Rewrites `migrate.sh` Phase 1 to use dynamic schema discovery + single dump/restore, fixing two critical bugs.

### Key Fixes

1. **Triggers silently lost** — The per-schema loop (`for schema in ...; do pg_dump; pg_restore; done`) restored schemas one at a time, but triggers on `public` tables referencing `auth.*` functions failed because `auth` wasn't restored yet. The old `--exit-on-error` flag caused pg_restore to abort the schema, silently discarding triggers.

   **Fix:** Single `pg_dump` with all `--schema=` flags → single `pg_restore`. pg_dump resolves inter-schema dependency ordering internally. Removed `--exit-on-error` and `--clean --if-exists` (target is fresh).

2. **Hardcoded schema list missed custom schemas** — `SCHEMAS=(public auth storage _realtime graphql_public extensions pgsodium)` missed user schemas like `private` and system schemas like `supabase_migrations`.

   **Fix:** Probe `information_schema.schemata` dynamically, excluding only Postgres built-in + `pg_temp_%` / `pg_toast_temp_%` (ephemeral Cloud connection-pool schemas that cause "unacceptable schema name" on restore).

3. **`supabase_admin` requirement documented** — `migrate.example.yml` now documents that `target.db_url` must use `supabase_admin` (superuser), not `postgres`, and provides the correct DSN format.

### Files Changed
- `migrate.sh` — Phase 1 probe + dump + restore rework, dry-run text updated
- `env/migrate.example.yml` — documentation of `supabase_admin` requirement, fixed default storage endpoints and region
- `AGENTS.md` — added Migration Script section documenting the key difficulties and their fixes