### PR TITLE
fix(supabase): bind Postgres SSL cert to the real Supabase domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ These are problems encountered while building this repo, and how they were fixed
 - **Mounted Postgres dirs and certs must use the image's real UID/GID** (currently 100/101 for the supabase postgres image), not guessed values.
 - **After cloning the Supabase repo as root, chown the whole tree to `deploy_user` recursively**, or the stack can't write to it.
 - **Kong route/plugin changes can break Kong's startup healthcheck** and take the whole API down (e.g. an `ip-restriction` plugin on `/mcp`). Test on a staging route before rolling out; keep risky config commented until the runtime rejection is understood.
+- **`foo.bar is defined` raises UndefinedError when `foo` itself is undefined** — guarding a nested attribute with `is defined` is not enough. Use `foo is defined and foo.bar is defined`, or `(foo | default({})).bar | default('')` for a chain.
+
+### Postgres SSL / Certificates
+- **Never put a config-driven value in `roles/*/defaults/main.yml`** — defaults are for constants only. The Postgres cert used to be generated with a hardcoded `postgres_domain: your-domain.com` placeholder, so every deployed cert had `CN=your-domain.com` and matched nothing. The role now reads `projects.supabase.domain` (the Caddy config domain, e.g. `sb.example.com`) directly, and an `assert` fails fast if it's still a placeholder.
+- **A self-signed cert with only a `CN` (no SANs) fails `sslmode=verify-full`.** Generate with `-addext "subjectAltName=DNS:<domain>,DNS:localhost,IP:127.0.0.1[,IP:<server_ip>]"` so hostname verification works whether clients connect by domain, loopback, or the server's public IP.
+- **`openssl req` writes the private key world-readable (0644)** and Postgres refuses to start ("private key file has group or world access"). chmod `0600` the key / `0644` the cert and chown both to the postgres image UID/GID (100/101) — done by the `Set ownership and permissions` task.
+- **The `creates:` guard meant an existing wrong cert was never regenerated** after a domain change. Check the live cert with `openssl x509 -noout -subject -nameopt RFC2253` and regenerate when it doesn't match the configured domain. Always use `-nameopt RFC2253` — the default subject format differs between OpenSSL 1.1.1 (`/CN=...`) and 3.x (`CN = ...`), which breaks naive `grep` comparisons.
+- **Prefer Caddy's real Let's Encrypt cert over self-signed** — look it up at `caddy_cert_base_path/<domain>/` (per-domain directory) and copy it; only fall back to self-signed when it's missing. The lookup only works if `caddy_cert_base_path` matches where Caddy actually stores certs.
+- **SSL was dead code until the compose args were uncommented** — the db container had `-c ssl=on` / `ssl_cert_file` / `ssl_key_file` commented out, so Postgres ignored the mounted certs entirely.
 
 ### setup.sh / config flow
 - **`set_env_var` uses `sed` on `key: value` lines — never run it on a list variable**, it corrupts the YAML (e.g. `docker_users`). For lists, replace only the `- item` line and leave the key line untouched.

--- a/roles/supabase/defaults/main.yml
+++ b/roles/supabase/defaults/main.yml
@@ -13,7 +13,6 @@ sb_db_version: supabase/postgres:17.6.1.136
 sb_supavisor_version: supabase/supavisor:2.9.5
 caddy_cert_base_path: "/home/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory"
 postgres_cert_path: "/opt/postgres-certs"
-postgres_domain: "your-domain.com"
 
 # MCP (Model Context Protocol) secure access.
 # The /mcp Kong route is restricted to these IPs only. Keep localhost-only

--- a/roles/supabase/tasks/main.yml
+++ b/roles/supabase/tasks/main.yml
@@ -34,9 +34,19 @@
     group: "101"
     mode: '0755'
 
+- name: Ensure Supabase public domain is configured
+  ansible.builtin.assert:
+    that:
+      - "(((projects | default({})).supabase | default({})).domain | default('')) not in ['', 'changeit', 'your-domain.com', 'sb.example.com']"
+    fail_msg: >-
+      projects.supabase.domain is not set to a real public domain. It is used to
+      locate the Caddy TLS certificate and to generate the Postgres SSL
+      certificate. Run setup.sh so it is rendered from required.supabase_domain.
+    quiet: yes
+
 - name: Check if Caddy certificate exists
   ansible.builtin.stat:
-    path: "{{ caddy_cert_base_path }}/{{ postgres_domain }}/{{ postgres_domain }}.crt"
+    path: "{{ caddy_cert_base_path }}/{{ projects.supabase.domain }}/{{ projects.supabase.domain }}.crt"
   register: caddy_cert
 
 - name: Ensure Certs directory exists
@@ -49,7 +59,7 @@
 
 - name: Copy Postgres SSL certificate
   ansible.builtin.copy:
-    src: "{{ caddy_cert_base_path }}/{{ postgres_domain }}/{{ postgres_domain }}.crt"
+    src: "{{ caddy_cert_base_path }}/{{ projects.supabase.domain }}/{{ projects.supabase.domain }}.crt"
     dest: "{{ postgres_cert_path }}/server.crt"
     remote_src: yes
     owner: "100"
@@ -59,7 +69,7 @@
 
 - name: Copy Postgres SSL key
   ansible.builtin.copy:
-    src: "{{ caddy_cert_base_path }}/{{ postgres_domain }}/{{ postgres_domain }}.key"
+    src: "{{ caddy_cert_base_path }}/{{ projects.supabase.domain }}/{{ projects.supabase.domain }}.key"
     dest: "{{ postgres_cert_path }}/server.key"
     remote_src: yes
     owner: "100"
@@ -68,20 +78,39 @@
   when: caddy_cert.stat.exists
 
 - name: Validate Postgres cert exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ postgres_cert_path }}/server.crt"
   register: pg_cert
 
-- name: Generate self-signed cert if Caddy's cert is missing
-  command: >
-    openssl req -x509 -nodes -days 365
-    -newkey rsa:2048
-    -keyout {{ postgres_cert_path }}/server.key
-    -out {{ postgres_cert_path }}/server.crt
-    -subj "/CN={{ postgres_domain }}"
-  args:
-    creates: "{{ postgres_cert_path }}/server.crt"
-  when: not pg_cert.stat.exists
+- name: Check Postgres cert matches the configured domain
+  ansible.builtin.shell: |
+    openssl x509 -in {{ postgres_cert_path }}/server.crt -noout -subject -nameopt RFC2253 | grep -q "CN={{ projects.supabase.domain }}"
+  register: pg_cert_check
+  failed_when: false
+  changed_when: false
+  when: pg_cert.stat.exists
+
+- name: Generate self-signed cert if missing or domain mismatch
+  ansible.builtin.shell: |
+    openssl req -x509 -nodes -days 365 \
+      -newkey rsa:2048 \
+      -keyout {{ postgres_cert_path }}/server.key \
+      -out {{ postgres_cert_path }}/server.crt \
+      -subj "/CN={{ projects.supabase.domain }}" \
+      -addext "subjectAltName=DNS:{{ projects.supabase.domain }},DNS:localhost,IP:127.0.0.1{% if ansible_default_ipv4 is defined and ansible_default_ipv4.address is defined %},IP:{{ ansible_default_ipv4.address }}{% endif %}"
+  when: >
+    (not pg_cert.stat.exists) or
+    (pg_cert_check.rc | default(1)) != 0
+
+- name: Set ownership and permissions on generated Postgres SSL files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "100"
+    group: "101"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ postgres_cert_path }}/server.key", mode: "0600" }
+    - { path: "{{ postgres_cert_path }}/server.crt", mode: "0644" }
 
 - name: Create Supabase files
   template:

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -505,13 +505,13 @@ services:
         "-c",
         "log_rotation_age=7d",
         "-c",
-        "log_statement=all"
-#        "-c",
-#        "ssl=on",
-#        "-c",
-#        "ssl_cert_file=/etc/postgres/certs/server.crt",
-#        "-c",
-#        "ssl_key_file=/etc/postgres/certs/server.key"
+        "log_statement=all",
+        "-c",
+        "ssl=on",
+        "-c",
+        "ssl_cert_file=/etc/postgres/certs/server.crt",
+        "-c",
+        "ssl_key_file=/etc/postgres/certs/server.key"
       ]
     restart: unless-stopped
     ports:

--- a/scripts/verify-secure-mcp.py
+++ b/scripts/verify-secure-mcp.py
@@ -52,7 +52,6 @@ def main():
         sb_supavisor_version="supabase/supavisor:latest",
         caddy_cert_base_path="/tmp",
         postgres_cert_path="/tmp",
-        postgres_domain="example.com",
         mcp_allowed_ips=["127.0.0.1", "::1"],
         deploy_user="deploy",
         deploy_env="prod",


### PR DESCRIPTION
Resolves #51 

## Problem

The Postgres SSL self-signed certificate generated by the `supabase` role had `CN=your-domain.com` — a hardcoded placeholder in `roles/supabase/defaults/main.yml` that was never wired to the real deployment domain (`projects.supabase.domain`, e.g. `sb.example.com`). Consequences:

- Every deployed cert matched nothing, so `sslmode=verify-full` clients failed hostname verification.
- The Caddy Let's Encrypt cert lookup used the same dead placeholder, so it never found the real cert and always fell back to self-signed.
- The `creates:` guard meant an already-deployed wrong cert was never regenerated after a domain change.
- The cert had no SANs, and the private key was world-readable (0644), which Postgres rejects.
- The `-c ssl=on` args were commented out in the compose stack, so the certs were dead code anyway.

## Changes

- **`roles/supabase/defaults/main.yml`** — removed the `postgres_domain: your-domain.com` placeholder. Config-driven values don't belong in role defaults.
- **`roles/supabase/tasks/main.yml`**
  - Use `projects.supabase.domain` directly for the Caddy cert lookup, copy, and CN/SAN.
  - `assert` fails fast if the domain is unset or still a placeholder (e.g. direct playbook runs without `setup.sh`).
  - Self-signed cert now includes `subjectAltName=DNS:<domain>,DNS:localhost,IP:127.0.0.1[,IP:<server_ip>]`.
  - Regenerates when the existing cert's CN (checked with `openssl x509 -noout -subject -nameopt RFC2253`) doesn't match the configured domain.
  - Key kept at `0600`, cert `0644`, both owned by the postgres image UID/GID (100/101).
- **`roles/supabase/templates/docker-compose-supabase.yml.j2`** — uncommented `ssl=on` / `ssl_cert_file` / `ssl_key_file` so Postgres actually serves TLS.
- **`scripts/verify-secure-mcp.py`** — dropped the stale `postgres_domain` entry from its defaults mirror.
- **`AGENTS.md`** — documented the Postgres SSL/cert pitfalls (defaults vs config-driven values, SAN requirement, key permissions, `creates:`/RFC2253 regeneration trap, preferring Caddy's LE cert, dead-code SSL args) plus the nested-`is defined` Jinja trap.

## Verification

- YAML/Python parse of all touched files.
- `bash -n setup.sh` passes.
- Rendered the compose template (valid YAML, `ssl=on` args present) and the tasks template (SAN with/without a server IP; assert evaluates cleanly when `projects` is undefined).
- Confirmed the RFC2253 subject output and `-addext` SANs against a locally generated cert.