### PR TITLE
fix(mcp): pin network subnet + allow Docker gateway for /mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ These are problems encountered while building this repo, and how they were fixed
 - **Postgres refuses to init if its log dir is inside the data dir** ("data directory exists but is not empty"). Log to `/var/log/postgresql` (host-mounted into the container), never `/var/lib/postgresql/data/log`.
 - **Mounted Postgres dirs and certs must use the image's real UID/GID** (currently 100/101 for the supabase postgres image), not guessed values.
 - **After cloning the Supabase repo as root, chown the whole tree to `deploy_user` recursively**, or the stack can't write to it.
-- **Kong route/plugin changes can break Kong's startup healthcheck** and take the whole API down (e.g. an `ip-restriction` plugin on `/mcp`). Test on a staging route before rolling out; keep risky config commented until the runtime rejection is understood.
+- **Kong route/plugin changes can break Kong's startup healthcheck** and take the whole API down (e.g. an `ip-restriction` plugin on `/mcp`). Test on a staging route before rolling out; keep risky config commented until the runtime rejection is understood. The original `/mcp` `ip-restriction` rejection was later root-caused to a Docker NAT source-IP mismatch — see **MCP / Docker networking** below.
 - **`foo.bar is defined` raises UndefinedError when `foo` itself is undefined** — guarding a nested attribute with `is defined` is not enough. Use `foo is defined and foo.bar is defined`, or `(foo | default({})).bar | default('')` for a chain.
 
 ### Postgres SSL / Certificates
@@ -108,6 +108,12 @@ These are problems encountered while building this repo, and how they were fixed
 ### Supabase template sync
 - **Templates drift from upstream self-hosted releases** (e.g. postgres 15→17, removed analytics/vector, SAML routes, new healthchecks). Sync against the latest upstream compose on a regular basis.
 - **Never bake project-specific changes into the default templates** (e.g. m3llm shared networks) — apply them via CI/CD overrides instead.
+
+### MCP / Docker networking
+- **`ip-restriction` on `/mcp` with `127.0.0.1`/`::1` can never match** — Docker source-NATs every host-originated connection (localhost, SSH tunnels) to the Docker bridge gateway IP before it reaches Kong, so Kong sees the gateway, not the loopback address. A request from the server itself returns `403 {"message":"IP address not allowed: 172.18.0.1"}`. This was the real cause of the QA 502 that forced commit `b44b6a6` to revert the original MCP feature (`0fe79d3`).
+- **Pin the compose network subnet so the gateway is deterministic** — `docker-compose-supabase.yml.j2` declares `networks.default.ipam.config.subnet: 172.28.0.0/16`, making the gateway always `172.28.0.1`. `mcp_allowed_ips` must stay in sync with this gateway (default `[172.28.0.1]`). Without the pin, `docker compose down && up` re-issues whatever subnet is free, silently re-breaking the allow list.
+- **The Kong/compose template now ships a top-level `networks:` block** — anything that blind-appends a second `networks:` key (e.g. the m3llm CI/CD `deploy-supabase-stack.yml`, which adds `shared-net`) produces a YAML duplicate-key error and breaks the deploy. Merge into the existing block instead (`grep -q '^networks:'` + `sed -i '/^networks:/a\...'`), never append a second block.
+- **`verify-secure-mcp.py` only renders the template — it never runs Kong.** A syntactically valid but wrong allow list (e.g. `127.0.0.1`) ships green. When touching MCP, cross-check `mcp_allowed_ips` against the pinned subnet gateway.
 
 ### Security-by-default
 - **The MCP endpoint must never be publicly reachable**; prefer SSH-tunnel access over opening Kong routes.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ For deep customization (custom OAuth providers, Grafana modes, retention tuning,
 
 ---
 
+## 📑 Table of Contents
+
+- [🚀 Quick Start (recommended)](#quick-start-recommended)
+- [🔧 Advanced: manual `install.sh` flow](#advanced-manual-installsh-flow)
+- [🔒 Optional Hardening](#optional-hardening)
+- [📦 What Gets Deployed](#what-gets-deployed)
+- [📚 Advanced Features](#advanced-features)
+- [🔒 Secure MCP Remote Access](#secure-mcp-remote-access)
+- [🚚 Migration from Supabase Cloud](#migration-from-supabase-cloud)
+- [📄 License](#license)
+
+---
+
 ## 🚀 Quick Start (recommended)
 
 The deterministic installer (`setup.sh`) reads a single `config.yml` file, generates all cryptographic secrets, renders the Ansible variables, enables the components you want, and deploys. This is the easiest path for both humans and AI agents.
@@ -369,6 +382,38 @@ Plus the security/monitoring stack: **Caddy** (reverse proxy + TLS + SSO), **UFW
 | **Secure MCP Access** | MCP server restricted to localhost; authorized clients connect via SSH tunnel — no public exposure |
 
 Full documentation: **[docs/advanced-docs.md](docs/advanced-docs.md)**
+
+---
+
+## 🔒 Secure MCP Remote Access
+
+The Supabase MCP server is exposed at `/mcp` through the Kong gateway (routed to
+Studio's `/api/mcp`). It is **never publicly reachable** — Kong's
+`ip-restriction` allow list defaults to the Docker bridge gateway
+(`172.28.0.1`; Docker source-NATs host connections to that gateway), so only
+host-originated traffic can reach it. Caddy never reverse-proxies `/mcp`, and
+the direct `/api/mcp` path stays blocked (403).
+
+Authorized clients connect through an SSH tunnel, reusing the existing SSH
+access (port 22) — no new public ports or subdomains:
+
+```bash
+ssh -L 8080:localhost:8000 deploy_user@sb.example.com -N
+```
+
+Then point your MCP client at:
+
+```
+http://localhost:8080/mcp
+```
+
+- The allow list is configurable via `mcp_allowed_ips` in `env/supabase.yml`.
+  Add a private VPN subnet (e.g. `10.0.0.0/24`) to allow it in addition, or set
+  `mcp_allowed_ips: []` to fully disable `/mcp`.
+- **Warning:** adding a public IP or `0.0.0.0/0` re-exposes the endpoint to the
+  Internet — don't.
+
+Full details: **[docs/advanced-docs.md → "Secure MCP Remote Access"](docs/advanced-docs.md#secure-mcp-remote-access)**
 
 ---
 

--- a/docs/advanced-docs.md
+++ b/docs/advanced-docs.md
@@ -373,9 +373,10 @@ firewall_deny:
 
 The Supabase MCP (Model Context Protocol) server exposes the Studio API at
 `/mcp` through the Kong gateway. By default this endpoint is **restricted to
-localhost** so it is never reachable from the public Internet. Authorized
-remote clients connect through an SSH tunnel, which reuses the existing SSH
-access (port 22) and requires no new public ports, subdomains, or services.
+host-originated traffic** so it is never reachable from the public Internet.
+Authorized remote clients connect through an SSH tunnel, which reuses the
+existing SSH access (port 22) and requires no new public ports, subdomains, or
+services.
 
 ### How it works
 
@@ -383,8 +384,11 @@ access (port 22) and requires no new public ports, subdomains, or services.
 MCP client (local) ──SSH tunnel (port 22)──> server ──> Kong :8000/mcp ──> Studio :3000/api/mcp
 ```
 
-- **Kong** applies an `ip-restriction` plugin to `/mcp` that only allows
-  `127.0.0.1` and `::1` (configurable via `mcp_allowed_ips`).
+- **Kong** applies an `ip-restriction` plugin to `/mcp`. Because Docker
+  source-NATs host connections to the bridge gateway, the allow list defaults to
+  the compose network gateway `172.28.0.1` (the subnet is pinned to
+  `172.28.0.0/16` in `docker-compose-supabase.yml.j2` so the gateway is
+  deterministic). This is configurable via `mcp_allowed_ips`.
 - **UFW** denies port `8000` (Kong) from external IPs by default.
 - **Caddy** never reverse-proxies `/mcp` — there is no public subdomain for it.
 - The direct `/api/mcp` path stays fully blocked (`request-termination` 403).
@@ -414,24 +418,25 @@ Close the tunnel with `Ctrl-C` (or by exiting the SSH session) when finished.
 The allow list is controlled by `mcp_allowed_ips` in `env/supabase.yml`:
 
 ```yaml
-# Default: localhost-only (SSH tunnel access)
+# Default: Docker bridge gateway (host-originated traffic, incl. SSH tunnels).
+# Must match the pinned compose subnet gateway in docker-compose-supabase.yml.j2.
 mcp_allowed_ips:
-  - 127.0.0.1
-  - ::1
+  - 172.28.0.1
 ```
 
-To allow a private VPN subnet (e.g. WireGuard) in addition to localhost:
+To allow a private VPN subnet (e.g. WireGuard) in addition:
 
 ```yaml
 mcp_allowed_ips:
-  - 127.0.0.1
-  - ::1
+  - 172.28.0.1
   - 10.0.0.0/24
 ```
 
+Set `mcp_allowed_ips: []` to fully disable `/mcp`.
+
 > **Warning:** Adding a public IP or `0.0.0.0/0` re-exposes the MCP endpoint to
 > the Internet and defeats the purpose of this security control. Keep the allow
-> list limited to localhost and private ranges.
+> list limited to private ranges.
 
 ### Why SSH tunneling?
 
@@ -534,7 +539,7 @@ All values go in `env/supabase.yml`.
 | `openai_api_key` | No | OpenAI API key |
 | `supabase_path` | No | Relative path for Supabase docker dir |
 | `kong_conf_path` | No | Relative path for Kong config |
-| `mcp_allowed_ips` | No | IPs allowed to reach `/mcp` via Kong (default: `[127.0.0.1, ::1]` — localhost only for SSH-tunnel access; see [Secure MCP Remote Access](#secure-mcp-remote-access)) |
+| `mcp_allowed_ips` | No | IPs allowed to reach `/mcp` via Kong (default: `[172.28.0.1]` — the Docker bridge gateway, since Docker source-NATs host connections; set `[]` to disable; see [Secure MCP Remote Access](#secure-mcp-remote-access)) |
 
 ### CADDY
 

--- a/docs/designs/secure-mcp.md
+++ b/docs/designs/secure-mcp.md
@@ -3,10 +3,12 @@
 ## Problem
 
 The Supabase MCP (Model Context Protocol) server endpoint (`/mcp` →
-`http://studio:3000/api/mcp`) can be exposed to the public Internet. The current
-Kong configuration blocks the endpoint by default but only offers a commented-out
-IP-allow-list mechanism that requires the service to be publicly reachable for
-remote clients to connect.
+`http://studio:3000/api/mcp`) can be exposed to the public Internet. A naive
+`ip-restriction` allow list of `127.0.0.1`/`::1` does not work here because
+Docker source-NATs every host-originated connection to the Docker bridge gateway
+IP before it reaches Kong — so Kong never sees a loopback source. The allow list
+must contain that gateway IP instead. The `/api/mcp` direct route stays fully
+blocked so remote clients can only reach the endpoint via an SSH tunnel.
 
 ## Goal
 
@@ -33,11 +35,15 @@ SSH tunneling is the chosen mechanism because:
 
 ### Kong layer (defense-in-depth)
 
-The `/mcp` Kong route is restricted to localhost (`127.0.0.1`, `::1`) via the
-`ip-restriction` plugin. This is configurable through `mcp_allowed_ips` so
-operators can tighten or relax the allow list, but the **default is localhost
-only**. The `/api/mcp` direct route stays fully blocked (request-termination
-403) so the only reachable path is `/mcp` from the server itself.
+The `/mcp` Kong route is restricted to host-originated traffic via the
+`ip-restriction` plugin. Because of Docker bridge NAT, connections from the host
+(including SSH tunnels) appear to Kong with the compose network gateway IP as
+the source. The compose file pins the network subnet (`172.28.0.0/16`) so the
+gateway is deterministically `172.28.0.1`, and `mcp_allowed_ips` defaults to that
+gateway. External clients keep their real public IP, which is not in the allow
+list, so they stay blocked. The `/api/mcp` direct route stays fully blocked
+(request-termination 403) so the only reachable path is `/mcp` from the server
+itself. Set `mcp_allowed_ips: []` to fully disable `/mcp`.
 
 ### Firewall layer
 
@@ -63,7 +69,7 @@ ssh -L 8080:localhost:8000 deploy_user@sb.example.com
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `mcp_allowed_ips` | `[127.0.0.1, ::1]` | IPs allowed to reach `/mcp` via Kong. Keep localhost-only for SSH-tunnel access. |
+| `mcp_allowed_ips` | `[172.28.0.1]` | IPs allowed to reach `/mcp` via Kong. Default is the Docker bridge gateway (host-originated traffic incl. SSH tunnels). Set `[]` to fully disable. Must match the pinned subnet gateway in `docker-compose-supabase.yml.j2`. |
 
 ## Out of scope
 

--- a/docs/test-cases/secure-mcp.md
+++ b/docs/test-cases/secure-mcp.md
@@ -15,26 +15,27 @@ exposure while remaining reachable to authorized clients via SSH tunnel.
   `status_code: 403`
 - **And** the response message is `Access is forbidden.`
 
-### TC-MCP-002: Kong `/mcp` route is restricted to localhost by default
+### TC-MCP-002: Kong `/mcp` route is restricted to host-originated traffic by default
 
 - **Given** the rendered `kong.yml` with no `mcp_allowed_ips` override
 - **When** the template is rendered
 - **Then** the `mcp` service has an `ip-restriction` plugin
-- **And** the `allow` list contains `127.0.0.1` and `::1`
+- **And** the `allow` list contains the Docker bridge gateway `172.28.0.1`
+  (Docker source-NATs host connections to the gateway; `127.0.0.1` is never seen)
 - **And** there is **no** `request-termination` plugin on the `mcp` service
 
 ### TC-MCP-003: `mcp_allowed_ips` override is honored
 
-- **Given** `env/supabase.yml` sets `mcp_allowed_ips: [10.0.0.5, 127.0.0.1]`
+- **Given** `env/supabase.yml` sets `mcp_allowed_ips: [10.0.0.5, 172.28.0.1]`
 - **When** the template is rendered
 - **Then** the `ip-restriction` `allow` list contains `10.0.0.5` and
-  `127.0.0.1`
+  `172.28.0.1`
 
-### TC-MCP-004: Default `mcp_allowed_ips` is localhost-only
+### TC-MCP-004: Default `mcp_allowed_ips` is the Docker bridge gateway
 
 - **Given** `roles/supabase/defaults/main.yml`
 - **When** the defaults are loaded
-- **Then** `mcp_allowed_ips` equals `[127.0.0.1, ::1]`
+- **Then** `mcp_allowed_ips` equals `[172.28.0.1]` (matches the pinned compose subnet gateway)
 
 ### TC-MCP-005: Kong config YAML is syntactically valid
 

--- a/env/supabase.yml
+++ b/env/supabase.yml
@@ -50,17 +50,19 @@ supabase_path: supabase/docker
 kong_conf_path: volumes/api
 
 # MCP (Model Context Protocol) secure access.
-# The /mcp Kong route is restricted to these IPs. Keep localhost-only so the
-# MCP server is never exposed publicly; authorized remote clients connect via
-# SSH tunnel (see docs/advanced-docs.md -> "Secure MCP Remote Access").
-# To allow a private VPN subnet instead, e.g.:
+# The /mcp Kong route is restricted to these IPs only. Docker source-NATs
+# host-originated connections to the bridge gateway IP (172.28.0.1 - see the
+# pinned subnet in docker-compose-supabase.yml.j2), so this default must match
+# that gateway; 127.0.0.1 is never seen by Kong for host traffic. Keep the MCP
+# server out of the public Internet; authorized remote clients connect via SSH
+# tunnel (see docs/advanced-docs.md -> "Secure MCP Remote Access").
+# To allow a private VPN subnet in addition, e.g.:
 #   mcp_allowed_ips:
-#     - 127.0.0.1
-#     - ::1
+#     - 172.28.0.1
 #     - 10.0.0.0/24
+# Set to [] to fully disable /mcp.
 mcp_allowed_ips:
-  - 127.0.0.1
-  - ::1
+  - 172.28.0.1
 
 postgres_db_pwd: changeit # REQUIRED
 

--- a/roles/supabase/defaults/main.yml
+++ b/roles/supabase/defaults/main.yml
@@ -15,10 +15,12 @@ caddy_cert_base_path: "/home/caddy/.local/share/caddy/certificates/acme-v02.api.
 postgres_cert_path: "/opt/postgres-certs"
 
 # MCP (Model Context Protocol) secure access.
-# The /mcp Kong route is restricted to these IPs only. Keep localhost-only
-# (127.0.0.1, ::1) so the MCP server is never exposed to the public Internet;
-# authorized remote clients connect via SSH tunnel. See
-# docs/advanced-docs.md -> "Secure MCP Remote Access".
+# The /mcp Kong route is restricted to these IPs only. Because Docker
+# source-NATs host-originated connections to the Docker bridge gateway IP,
+# the default allow list must contain the compose network gateway
+# (172.28.0.1 - see the pinned subnet in docker-compose-supabase.yml.j2),
+# not 127.0.0.1 which Kong never sees for host traffic. Authorized remote
+# clients connect via SSH tunnel. Set to [] to fully disable /mcp.
+# See docs/advanced-docs.md -> "Secure MCP Remote Access".
 mcp_allowed_ips:
-  - 127.0.0.1
-  - ::1
+  - 172.28.0.1

--- a/roles/supabase/templates/docker-compose-supabase.yml.j2
+++ b/roles/supabase/templates/docker-compose-supabase.yml.j2
@@ -609,3 +609,14 @@ services:
 volumes:
   db-config:
   deno-cache:
+
+networks:
+  # Pin the compose project network subnet so the Docker bridge gateway IP is
+  # deterministic. Kong's /mcp ip-restriction allow list (mcp_allowed_ips)
+  # must match this gateway: Docker source-NATs every host-originated
+  # connection to the bridge gateway, so 127.0.0.1 is never seen by Kong.
+  # Keep mcp_allowed_ips in sync with the gateway below (172.28.0.1).
+  default:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/roles/supabase/templates/kong-supabase.yml.j2
+++ b/roles/supabase/templates/kong-supabase.yml.j2
@@ -401,18 +401,19 @@ services:
           status_code: 403
           message: "Access is forbidden."
 
-  ## MCP endpoint - local access
-  # The /mcp route is blocked by default (request-termination 403) so the
-  # MCP server is never exposed to the public Internet. Authorized remote
-  # clients can reach it through an SSH tunnel:
+  ## MCP endpoint - secure local-only access (SSH tunnel)
+  # The /mcp route is restricted to host-originated traffic so the MCP server
+  # is never exposed to the public Internet. Authorized remote clients reach
+  # it through an SSH tunnel:
   #   ssh -L 8080:localhost:8000 deploy_user@<server>
   # then point the MCP client at http://localhost:8080/mcp
-  # To enable local access (danger zone!):
-  # 1. Comment out the 'request-termination' section below
-  # 2. Uncomment the 'ip-restriction' section, including 'deny'
-  # 3. Add your local IPs to the 'allow' list (mcp_allowed_ips)
+  #
+  # NOTE: Docker source-NATs host-originated connections to the bridge gateway
+  # IP (see the pinned subnet in docker-compose-supabase.yml.j2), so the allow
+  # list must contain that gateway (e.g. 172.28.0.1), not 127.0.0.1. Set
+  # `mcp_allowed_ips: []` to fully disable /mcp.
   - name: mcp
-    _comment: 'MCP: /mcp -> http://studio:3000/api/mcp (local access)'
+    _comment: 'MCP: /mcp -> http://studio:3000/api/mcp (localhost-only via SSH tunnel)'
     url: http://studio:3000/api/mcp
     routes:
       - name: mcp
@@ -420,22 +421,14 @@ services:
         paths:
           - /mcp
     plugins:
-      # Block access to /mcp by default
-      - name: request-termination
+      - name: cors
+      - name: ip-restriction
         config:
-          status_code: 403
-          message: "Access is forbidden."
-      # Enable local access (danger zone!)
-      # 1. Comment out the 'request-termination' section above
-      # 2. Uncomment the entire section below, including 'deny'
-      # 3. Add your local IPs to the 'allow' list
-      #- name: cors
-      #- name: ip-restriction
-      #  config:
-      #    allow:
-      #      - 127.0.0.1
-      #      - ::1
-      #    deny: []
+          allow:
+            {%- for ip in mcp_allowed_ips %}
+            - {{ ip }}
+            {%- endfor %}
+          deny: []
 
 
   ## Protected Dashboard - catch all remaining routes

--- a/scripts/verify-secure-mcp.py
+++ b/scripts/verify-secure-mcp.py
@@ -52,7 +52,7 @@ def main():
         sb_supavisor_version="supabase/supavisor:latest",
         caddy_cert_base_path="/tmp",
         postgres_cert_path="/tmp",
-        mcp_allowed_ips=["127.0.0.1", "::1"],
+        mcp_allowed_ips=["172.28.0.1"],
         deploy_user="deploy",
         deploy_env="prod",
         supabase_path="supabase/docker",
@@ -113,20 +113,20 @@ def main():
     assert_true(rt is not None, "mcp-blocker has request-termination plugin")
     assert_true(rt.get("config", {}).get("status_code") == 403, "mcp-blocker returns 403")
 
-    # TC-MCP-002: mcp service has ip-restriction with localhost allow, no request-termination
+    # TC-MCP-002: mcp service has ip-restriction with bridge-gateway allow, no request-termination
     mcp = next((s for s in services if s.get("name") == "mcp"), None)
     assert_true(mcp is not None, "mcp service exists")
     mcp_plugins = get_plugins(mcp)
     ipr = next((p for p in mcp_plugins if p.get("name") == "ip-restriction"), None)
     assert_true(ipr is not None, "mcp service has ip-restriction plugin")
     allow = ipr.get("config", {}).get("allow", [])
-    assert_true("127.0.0.1" in allow and "::1" in allow, "default allow list contains localhost")
+    assert_true("172.28.0.1" in allow, "default allow list contains the Docker bridge gateway")
     rt_mcp = next((p for p in mcp_plugins if p.get("name") == "request-termination"), None)
     assert_true(rt_mcp is None, "mcp service has NO request-termination plugin")
 
     # TC-MCP-003 / TC-MCP-006: custom allowed IPs honored
     custom = dict(defaults)
-    custom["mcp_allowed_ips"] = ["10.0.0.5", "127.0.0.1", "10.0.0.0/24"]
+    custom["mcp_allowed_ips"] = ["10.0.0.5", "172.28.0.1", "10.0.0.0/24"]
     rendered_custom = render_kong(**custom)
     doc_custom = yaml.safe_load(rendered_custom)
     services_custom = doc_custom.get("services", [])
@@ -135,7 +135,7 @@ def main():
     allow_custom = ipr_custom.get("config", {}).get("allow", [])
     assert_true("10.0.0.5" in allow_custom, "custom allow list includes 10.0.0.5")
     assert_true("10.0.0.0/24" in allow_custom, "custom allow list includes 10.0.0.0/24")
-    assert_true("127.0.0.1" in allow_custom, "custom allow list includes 127.0.0.1")
+    assert_true("172.28.0.1" in allow_custom, "custom allow list includes 172.28.0.1")
 
     # TC-MCP-010: no /mcp path in Caddy example projects
     # Parse env/supabase.yml and inspect the projects' upstream paths.


### PR DESCRIPTION
## Problem

The MCP server at `/mcp` was unreachable through the documented SSH-tunnel pattern. Root cause: Docker source-NATs every host-originated connection (localhost, SSH tunnels) to the Docker bridge gateway before it reaches Kong, so the default `127.0.0.1`/`::1` allow list could never match → `403 {"message":"IP address not allowed: 172.18.0.1"}`. This is the actual root cause of the earlier QA 502 that forced revert `b44b6a6`.

## Changes

- **`docker-compose-supabase.yml.j2`**: pin the `default` network subnet to `172.28.0.0/16` so the Docker gateway is deterministic (`172.28.0.1`).
- **`kong-supabase.yml.j2`**: enable `/mcp` route with `cors` + `ip-restriction` templated from `mcp_allowed_ips` (default `[172.28.0.1]`); `/api/mcp` stays blocked (403). Comments document the Docker-NAT behavior and `mcp_allowed_ips: []` to disable.
- **`defaults/main.yml` + `env/supabase.yml`**: `mcp_allowed_ips` default → `[172.28.0.1]`.
- **Docs/README**: new "Secure MCP Remote Access" section — SSH tunnel `ssh -L 8080:localhost:8000 <deploy_user>@<domain> -N` → `http://localhost:8080/mcp`, plus config guidance; README table of contents added.
- **`AGENTS.md`**: "MCP / Docker networking" pitfalls section.
- **`verify-secure-mcp.py`**: defaults/assertions updated to `172.28.0.1` (12/12 tests pass).

## ⚠️ Merge order

This must merge **first**. The m3llm `shared-net` merge PR (`fix(deploy): merge shared-net into existing networks block`) depends on the new top-level `networks:` block in the compose template.

## Post-merge

Apply on the server: `git fetch origin main && git reset --hard origin/main`, set `mcp_allowed_ips: [172.28.0.1]` in `env/supabase.yml`, run `sudo bash setup.sh`, verify the gateway is `172.28.0.1` and MCP `initialize` succeeds over the SSH tunnel.