### PR TITLE
docs(readme): fix table-of-contents anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ For deep customization (custom OAuth providers, Grafana modes, retention tuning,
 
 ## 📑 Table of Contents
 
-- [🚀 Quick Start (recommended)](#quick-start-recommended)
-- [🔧 Advanced: manual `install.sh` flow](#advanced-manual-installsh-flow)
-- [🔒 Optional Hardening](#optional-hardening)
-- [📦 What Gets Deployed](#what-gets-deployed)
-- [📚 Advanced Features](#advanced-features)
-- [🔒 Secure MCP Remote Access](#secure-mcp-remote-access)
-- [🚚 Migration from Supabase Cloud](#migration-from-supabase-cloud)
-- [📄 License](#license)
+- [🚀 Quick Start (recommended)](#-quick-start-recommended)
+- [🔧 Advanced: manual `install.sh` flow](#-advanced-manual-installsh-flow)
+- [🔒 Optional Hardening](#-optional-hardening)
+- [📦 What Gets Deployed](#-what-gets-deployed)
+- [📚 Advanced Features](#-advanced-features)
+- [🔒 Secure MCP Remote Access](#-secure-mcp-remote-access)
+- [🚚 Migration from Supabase Cloud](#-migration-from-supabase-cloud)
+- [📄 License](#-license)
 
 ---
 


### PR DESCRIPTION
## Problem

The README table of contents links to the top of the page instead of their sections.

**Root cause:** GitHub generates heading anchors that keep the emoji as a leading hyphen — e.g. `## 🚀 Quick Start (recommended)` → `#-quick-start-recommended`, not `#quick-start-recommended`.

## Changes

- Prefixed every ToC link with the leading `-` so each entry jumps to its section.
- Anchors verified against GitHub's rendered HTML (`user-content--*` ids).