### PR TITLE
fix(monitor): wrap server-stats dashboard in raw (keep Grafana {{label}} refs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ These are problems encountered while building this repo, and how they were fixed
 - **Promtail can't read Docker container logs without both** the `/var/lib/docker/containers` mount and a `docker: {}` pipeline stage.
 - **Bind Grafana/Loki/Prometheus/cAdvisor/node-exporter/Studio to `127.0.0.1` by default** — do not expose monitoring/admin ports on all interfaces.
 - **Grafana home dashboards are silently ignored unless wired in**: templates must be named `home.json.j2`, copied to the target path, and enabled via `default_home_dashboard_path` in grafana.ini. Duplicate `home.json` / `home.json.j2` files cause confusion.
+- **Grafana dashboard exports use `{{label_name}}` legend syntax that collides with Ansible**: a verbatim dashboard JSON shipped as `server-stats.json.j2` rendered `{{device}}`/`{{name}}`/`{{instance}}` as Ansible vars and failed with `'device' is undefined`. Wrap dashboard JSON in `{% raw %}`...`{% endraw %}` (renders byte-identical; no real Ansible vars in such files).
 - **Never hardcode an OAuth provider as `enabled = true`** — gate it behind a toggle so placeholder credentials can't break Grafana startup.
 
 ### Caddy / SSO

--- a/roles/monitor/templates/server-stats.json.j2
+++ b/roles/monitor/templates/server-stats.json.j2
@@ -1,4 +1,4 @@
-{
+{% raw %}{
   "annotations": [
     {
       "kind": "AnnotationQuery",
@@ -3963,3 +3963,4 @@
     }
   ]
 }
+{% endraw %}


### PR DESCRIPTION
## Problem

The monitor role fails during deploy on `server-stats.json`:

```
AnsibleUndefinedVariable: 'device' is undefined. 'device' is undefined
```

**Root cause:** `roles/monitor/templates/server-stats.json.j2` is a verbatim Grafana dashboard export that uses Grafana's `{{label_name}}` legend syntax (`{{device}}`, `{{name}}`, `{{instance}}` — 12 occurrences). The role's `template:` task renders the `.j2` with Jinja, so Ansible tries to resolve them as variables. `{{device}}` is the first to fail; `{{name}}`/`{{instance}}` would fail next.

## Changes

- **`roles/monitor/templates/server-stats.json.j2`** — wrapped in `{% raw %}`…`{% endraw %}`. Verified it renders **byte-identical** to the original JSON (all 12 `{{label}}` refs preserved) under every `trim_blocks`/`lstrip_blocks` combination.
- **`AGENTS.md`** — pitfall documented under Monitoring.

No m3llm changes needed; the next `deploy-supabase-stack.yml` run regenerates the dashboard from the fixed template. Also fixes leadminer's next monitor redeploy (same failure would occur).