### PR TITLE
feat(manifest+agent): emit instance manifest, connect agents over SSH stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
 # Ansible Supabase
 
-One-command deployment of a **self-hosted, production-ready Supabase stack** on any Debian/Ubuntu server. The playbook installs Docker, clones the latest Supabase release, generates all configuration files, and starts the full stack — secured by default with automatic TLS, SSO/OAuth2, basic auth, IP allow-listing, a firewall, and brute-force protection.
+One-command deployment of a **self-hosted, production-ready Supabase stack** on Debian, Ubuntu, or Arch Linux. The playbook installs Docker, clones the latest Supabase release, generates all configuration files, and starts the full stack — secured by default with automatic TLS, SSO/OAuth2, basic auth, IP allow-listing, a firewall, and brute-force protection.
 
 This repository's purpose is to give you a **ready-to-use, full-featured Supabase with security, encryption, and SSO/auth baked in** — not a bare dashboard exposed to the internet.
 
 > **Encryption at rest (LUKS) and automated S3 backups** are included and ready to enable; they need a dedicated disk volume and S3 credentials respectively, so they are shown as optional hardening steps at the end of this guide.
 
 For deep customization (custom OAuth providers, Grafana modes, retention tuning, version pinning) see [docs/advanced-docs.md](docs/advanced-docs.md).
+
+### Server support matrix
+
+All Tier 1 targets — full stack CI on every PR:
+
+| Target | Notes |
+|--------|-------|
+| Ubuntu 24.04, Ubuntu 22.04 | the default assumption in this README |
+| Debian 12 | |
+| Arch | rolling, tracks upstream Docker |
+
+Out of scope (stated here so nobody discovers it at run time): **RHEL family** (SELinux needs its own work) and **Manjaro as a server target** (it's a desktop distro — it appears in this repo only on the client side, in [docs/connect-your-agent.md](docs/connect-your-agent.md)).
+
+The role detects the distro family from `ID_LIKE` in `/etc/os-release` (never `ID` — Mint and Pop!\_OS report `ID_LIKE=ubuntu debian`, which buys most derivatives for free).
 
 ---
 
@@ -17,6 +31,7 @@ For deep customization (custom OAuth providers, Grafana modes, retention tuning,
 - [🔒 Optional Hardening](#-optional-hardening)
 - [📦 What Gets Deployed](#-what-gets-deployed)
 - [📚 Advanced Features](#-advanced-features)
+- [🤖 Connect Your AI Agent](#-connect-your-ai-agent)
 - [🔒 Secure MCP Remote Access](#-secure-mcp-remote-access)
 - [🚚 Migration from Supabase Cloud](#-migration-from-supabase-cloud)
 - [📄 License](#-license)
@@ -29,7 +44,7 @@ The deterministic installer (`setup.sh`) reads a single `config.yml` file, gener
 
 ### 1. 📋 Prerequisites
 
-- A **Debian/Ubuntu server** with root or sudo access
+- A **Debian 12, Ubuntu 22.04/24.04, or Arch Linux server** with root or sudo access (see the [server support matrix](#server-support-matrix) above)
 - A **domain** with three DNS A records pointing to your server:
   - `sb.example.com` — Supabase dashboard + API
   - `auth.example.com` — OAuth2 authentication endpoint
@@ -367,6 +382,11 @@ Then uncomment the `backup` role in `playbook-supabase.yml` (see step 5).
 
 Plus the security/monitoring stack: **Caddy** (reverse proxy + TLS + SSO), **UFW** firewall, **Fail2ban**, and **Grafana/Prometheus/Loki**.
 
+Every deployment also writes:
+- **`/etc/supabase/instance.json`** — the instance manifest (JSON contract: ports, container names, endpoints, secret *locations*). No secret values, ever.
+- **`/usr/local/bin/supabase-agent`** — an MCP server over SSH stdio for AI agents (read-only tools, no secret values).
+- **`/usr/local/bin/supabase-selfhosted`** — a CLI to read the manifest and resolve secrets (TTY-aware redaction).
+
 ---
 
 ## 📚 Advanced Features
@@ -380,12 +400,58 @@ Plus the security/monitoring stack: **Caddy** (reverse proxy + TLS + SSO), **UFW
 | **Fail2ban** | Brute-force protection for PostgreSQL |
 | **UFW Firewall** | Fine-grained allow/deny rules |
 | **Secure MCP Access** | MCP server restricted to localhost; authorized clients connect via SSH tunnel — no public exposure |
+| **Instance Manifest** | `/etc/supabase/instance.json` — a JSON contract describing the instance (ports, containers, endpoints, secret locations) |
+| **SSH-stdio Agent** | `/usr/local/bin/supabase-agent` — MCP over SSH stdio for AI agents; read-only tools, no secret values |
+| **Info CLI** | `supabase-selfhosted info` — reads the manifest, resolves secrets with TTY-aware redaction |
 
 Full documentation: **[docs/advanced-docs.md](docs/advanced-docs.md)**
 
 ---
 
-## 🔒 Secure MCP Remote Access
+## 🤖 Connect Your AI Agent
+
+Every deployment writes an **instance manifest** to `/etc/supabase/instance.json` — a JSON contract describing the instance (database ports, container names, endpoints, secret *locations* — never secret *values*). It also generates an ed25519 SSH key restricted to running `/usr/local/bin/supabase-agent`, an MCP server over stdio that exposes read-only tools (no secret values ever).
+
+At the end of a fresh deployment, the playbook prints the private key **once**, plus a ready-to-paste `~/.ssh/config` block and an MCP client config snippet. To connect your agent (Claude Code, Codex, opencode, pi — they all take the same `{command, args}` shape), follow the one-page guide:
+
+**[docs/connect-your-agent.md](docs/connect-your-agent.md)**
+
+Then verify the connection with:
+
+```bash
+sh scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent
+```
+
+The verify script is POSIX-clean and runs on both GNU and BSD userland (Linux + macOS).
+
+### Reading secrets back
+
+`supabase-selfhosted info` reads the manifest and resolves the secret references against the `.env` file. **The default flips on whether stdout is a TTY**: a human at a terminal gets the real values (the "what was my service_role key again" recovery path); a pipe, file, or captured stream gets `••••` plus the reference.
+
+```bash
+# On the server, at a terminal — shows real values:
+supabase-selfhosted info
+
+# Piped (redacted):
+supabase-selfhosted info | cat
+
+# Force reveal (for `| pbcopy`):
+supabase-selfhosted info --show-secrets | pbcopy
+
+# Force redaction (for screen sharing):
+supabase-selfhosted info --no-secrets
+
+# JSON output (redacted unless --show-secrets):
+supabase-selfhosted info --json
+```
+
+The MCP agent connects with `no-pty`, so it never sees a value it didn't explicitly ask for — and **no MCP tool returns secret values**.
+
+### v2 (deferred)
+
+This is **v1**: the playbook writes nothing on your machine — it prints a snippet, and the docs explain where to put it. **v2** will automate the client side: generate the key into `~/.ssh`, write the `Host` block behind managed markers, and update agent config files (backed up first). It's the difference between "paste one block" and "nothing to paste", and it isn't worth blocking the server work on.
+
+---
 
 The Supabase MCP server is exposed at `/mcp` through the Kong gateway (routed to
 Studio's `/api/mcp`). It is **never publicly reachable** — Kong's

--- a/docs/connect-your-agent.md
+++ b/docs/connect-your-agent.md
@@ -1,0 +1,235 @@
+# Connect Your AI Agent
+
+Connect Claude Code, Codex, opencode, or pi to your self-hosted Supabase via
+SSH stdio. The Ansible role `instance-manifest-ssh-agent` provisions a
+dedicated, command-restricted SSH key on the server. Your agent runs the
+remote command `supabase-agent`, which speaks MCP-over-stdio through the
+authenticated SSH channel.
+
+The agent config — `{ command, args }` — is identical for every agent. Only
+the file you put it in differs.
+
+---
+
+## Prerequisites
+
+- The server is already deployed via `ansible-supabase` (the
+  `instance-manifest-ssh-agent` role must have run).
+- You have the deployment output: a **private key** and an **SSH config
+  block** containing `Host supabase-agent`, `HostName`, `User`, and
+  `IdentityFile`.
+- Your local machine has an OpenSSH client (`ssh -V` should print a version).
+  On Manjaro, install it with `sudo pacman -S openssh` if it is missing.
+
+---
+
+## Step 1 — Install the private key
+
+> **`~/.ssh` must be mode `0700`.** If the directory is group- or
+> world-readable, `ssh` refuses to use keys inside it. The error message
+> misleadingly points at the key file (`Permissions ... are too open`),
+> not at the directory. Run `chmod 0700 ~/.ssh` first if needed.
+
+Create the key file with the correct mode, then paste the private key
+printed by the deployment:
+
+```sh
+# Replace <host> with the server's name (e.g. myserver, prod, vps1)
+install -m 0600 /dev/null ~/.ssh/supabase-agent-<host>
+${EDITOR:-vi} ~/.ssh/supabase-agent-<host>
+# paste the key, save, exit
+```
+
+The path is `~/.ssh/supabase-agent-<host>`, mode `0600`. Never share this
+file or check it into version control.
+
+---
+
+## Step 2 — Add the SSH config block
+
+The deployment also prints an `Host supabase-agent` block. Paste it into
+`~/.ssh/config` (create the file with mode `0600` if it does not exist):
+
+```
+Host supabase-agent
+  HostName <your-server-ip-or-domain>
+  User <deploy_user>
+  IdentityFile ~/.ssh/supabase-agent-<host>
+  IdentitiesOnly yes
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/supabase-agent-%r@%h:%p
+  ControlPersist 10m
+```
+
+`ControlPath` points to `~/.ssh/sockets/`, so the directory must exist or
+SSH will fail the connection silently. Create it once:
+
+```sh
+mkdir -p ~/.ssh/sockets
+chmod 0700 ~/.ssh
+chmod 0700 ~/.ssh/sockets
+```
+
+Replace `<host>`, `<your-server-ip-or-domain>`, and `<deploy_user>` with
+the values from your deployment output. The alias (`supabase-agent`) is
+the literal name used by all four agents in Step 3 — do not rename it
+unless you also update the agent config.
+
+> **macOS** — OpenSSH is preinstalled; `ControlMaster` works the same
+> way. The config block is identical. No changes needed.
+
+---
+
+## Step 3 — Configure your agent
+
+All four agents take the same `command` + `args` shape:
+
+```
+command:  ssh
+args:     [supabase-agent, supabase-agent]
+```
+
+The first `supabase-agent` is the SSH alias. The second is the command
+the server runs, which starts the MCP server on stdio. The file you put
+this in differs per agent.
+
+**Claude Code** — `.mcp.json` in the project root, or globally:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "ssh",
+      "args": ["supabase-agent", "supabase-agent"]
+    }
+  }
+}
+```
+
+Or via the CLI: `claude mcp add supabase -- ssh supabase-agent supabase-agent`
+
+**Codex** — `~/.codex/config.toml`:
+
+```toml
+[[mcp_servers]]
+name = "supabase"
+command = "ssh"
+args = ["supabase-agent", "supabase-agent"]
+```
+
+**opencode** — `~/.config/opencode/opencode.json` (or in the project's
+`opencode.json`):
+
+```json
+{
+  "mcp": {
+    "supabase": {
+      "type": "local",
+      "command": ["ssh", "supabase-agent", "supabase-agent"]
+    }
+  }
+}
+```
+
+**pi** — `~/.pi/agent/mcp.json` (check your version's docs for the
+exact path):
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "ssh",
+      "args": ["supabase-agent", "supabase-agent"]
+    }
+  }
+}
+```
+
+> The exact config file paths and JSON keys can change between agent
+> versions. If a path above does not match your install, consult your
+> agent's MCP documentation for the current location — but the
+> `command` / `args` shape is universal and will not change.
+
+Restart your agent after editing the config so it picks up the new MCP
+server.
+
+---
+
+## Step 4 — Verify
+
+From the repository checkout (the same one you used to deploy), run the
+verification script:
+
+```sh
+./scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent
+```
+
+The script checks, in order:
+
+1. `~/.ssh` is mode `0700`.
+2. `~/.ssh/sockets/` exists (creates it if missing).
+3. The private key file exists and is mode `0600`.
+4. `~/.ssh/config` has a `Host supabase-agent` block.
+5. `ssh ... whoami` is **rejected** (the command restriction blocks
+   shell access — this must fail).
+6. `ssh ... -L 9999:localhost:9999 true` is **rejected** (port
+   forwarding is blocked).
+7. An MCP `initialize` request piped into `ssh ... supabase-agent`
+   returns a JSON object (first byte is `{`).
+
+The script exits `0` on success and `1` if any check fails. It is
+POSIX-clean and works on both Linux (GNU) and macOS (BSD) userland — it
+does not branch on `uname` and contains no bashisms.
+
+---
+
+## Troubleshooting
+
+**`Permission denied (publickey)`**
+
+Two common causes, both about file modes:
+
+- The private key is not mode `0600`. Run `chmod 0600 ~/.ssh/supabase-agent-<host>`.
+- `~/.ssh` is not mode `0700`. Run `chmod 0700 ~/.ssh`. Note that the
+  error message from `ssh` points at the key file, not the directory —
+  the directory is the real culprit.
+
+**`Could not resolve hostname supabase-agent` / `ssh: Could not connect`**
+
+- The `Host supabase-agent` block is missing from `~/.ssh/config`. Add
+  it from Step 2.
+- The server is down, or port `22` is blocked. Test with
+  `ssh -v -i ~/.ssh/supabase-agent-<host> <user>@<host> true` (replace
+  `<host>` with the IP or domain from the config block) — the
+  unrestricted key from your server admin can do this; the agent key
+  cannot.
+- `~/.ssh/sockets/` does not exist and `ControlPath` is failing
+  silently. Run `mkdir -p ~/.ssh/sockets`.
+
+**`bash: supabase-agent: command not found`**
+
+The `instance-manifest-ssh-agent` role did not run successfully on the
+server, or its install task was skipped. Re-run the playbook:
+
+```sh
+./setup.sh && ./install.sh
+```
+
+…or re-run the role directly with `ansible-playbook
+playbook-supabase.yml --tags instance-manifest-ssh-agent`.
+
+**MCP server returns non-JSON or hangs**
+
+The first byte of the response should be `{`. If it is something else,
+or if the script times out on Step 7, the remote `supabase-agent`
+binary may be missing or broken. SSH to the server with an
+unrestricted key and check:
+
+```sh
+sudo -iu <deploy_user> command -v supabase-agent
+sudo -iu <deploy_user> supabase-agent < /dev/null
+```
+
+The second command should print a JSON-RPC error to stderr (or exit
+non-zero) because no `initialize` was sent — that confirms the binary
+is present and runnable.

--- a/docs/test-cases/issue-120.md
+++ b/docs/test-cases/issue-120.md
@@ -1,0 +1,141 @@
+# Test Cases — Issue #120: Instance Manifest + SSH stdio Agent
+
+Tracks the acceptance criteria from [issue #120](https://github.com/ankaboot-source/ansible-supabase/issues/120). Each test maps to one or more acceptance checkboxes.
+
+## TC-MANIFEST-001: Fresh install produces a valid manifest
+**Acceptance:** Fresh install on all 3 server targets produces a manifest valid against the schema.
+**Steps:**
+1. Run the full playbook on a fresh Ubuntu 24.04, Debian 12, and Arch server.
+2. Read `/etc/supabase/instance.json`.
+3. Validate against the schema (schema_version=1, required fields present).
+**Expected:** Valid JSON with all fields: `schema_version`, `generated_at`, `generated_by`, `supabase.{version,installed_at}`, `db.{host,port_direct,port_pooler,tenant_id,user,dbname,sslmode}`, `paths.{docker_dir,functions_volume,env_file}`, `containers.{db,edge_runtime,kong,auth,storage,rest}`, `endpoints.{api,studio}`, `secrets.*`.
+**Targets:** Ubuntu 24.04, Ubuntu 22.04, Debian 12, Arch.
+
+## TC-MANIFEST-002: `--tags manifest` regenerates without touching the stack
+**Acceptance:** `--tags manifest` regenerates it without touching the stack.
+**Steps:**
+1. After a full deploy, note the running container IDs: `docker ps -q`.
+2. Run `ansible-playbook playbook-supabase.yml --tags manifest -e @env/supabase.yml`.
+3. Check container IDs again: `docker ps -q`.
+**Expected:** Manifest `generated_at` updated; container IDs unchanged (no restart).
+
+## TC-MANIFEST-003: Second full run updates `generated_at`, byte-identical otherwise
+**Acceptance:** A second full run updates `generated_at` and is otherwise byte-identical.
+**Steps:**
+1. After a full deploy, copy the manifest: `cp /etc/supabase/instance.json /tmp/run1.json`.
+2. Run the full playbook again.
+3. Diff: `diff <(jq 'del(.generated_at)' /tmp/run1.json) <(jq 'del(.generated_at)' /etc/supabase/instance.json)`.
+**Expected:** Empty diff (only `generated_at` changed). `installed_at` preserved.
+
+## TC-MANIFEST-004: No `.env` value appears in the manifest
+**Acceptance:** Automated check: no value from `.env` appears anywhere in manifest.
+**Steps:**
+1. After a full deploy, extract every `KEY=VALUE` from `/home/<deploy_user>/supabase/docker/.env`.
+2. For each value (non-empty, non-placeholder), `grep -F -c '<value>' /etc/supabase/instance.json`.
+3. Also rely on the role's built-in leak assertions (4 `grep -F` checks for `postgres_db_pwd`, `sb_jwt_secret`, `sb_anon_key`, `sb_service_role_key`).
+**Expected:** Zero matches for every secret value. The role's assertion tasks fail the run if any leak is detected.
+
+---
+
+## TC-SSH-001: Key cannot open a shell
+**Acceptance:** `ssh -i <key> <host> whoami` fails — the key cannot open a shell.
+**Steps:**
+1. `ssh -i ~/.ssh/supabase-agent-<host> <alias> whoami`
+**Expected:** Fails (non-zero exit). The `command="..."` restriction in authorized_keys forces the agent binary, ignoring the requested command.
+
+## TC-SSH-002: Port forwarding refused
+**Acceptance:** `ssh -i <key> -L 9999:localhost:9999 <host>` fails — forwarding is refused.
+**Steps:**
+1. `ssh -i ~/.ssh/supabase-agent-<host> -L 9999:localhost:9999 -fN <alias>` (or without `-fN`).
+**Expected:** Fails. The `no-port-forwarding` restriction in authorized_keys blocks it.
+
+## TC-SSH-003: MCP byte test
+**Acceptance:** Piping an MCP `initialize` into `ssh <alias> supabase-agent` returns a stream whose first byte is `{`. Distro-agnostic.
+**Steps:**
+1. `printf '%s' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}' | ssh <alias> supabase-agent | head -c 1 | od -c | head -1`
+**Expected:** First byte is `{` (0000000   {). No shell preamble, no MOTD, no banner pollutes stdout.
+**Targets:** Ubuntu 24.04, Debian 12, Arch.
+
+---
+
+## TC-SECRET-001: `info` on terminal shows real values
+**Acceptance:** `supabase-selfhosted info` on a terminal shows real values.
+**Steps:**
+1. SSH into the server with a TTY: `ssh <user>@<host>`.
+2. Run `supabase-selfhosted info`.
+**Expected:** Real connection strings, anon key, service_role key, JWT secret, dashboard credentials shown.
+
+## TC-SECRET-002: Piped/redirected/over ssh shows `••••` + reference
+**Acceptance:** Piped, redirected, or run over `ssh <alias> supabase-selfhosted info`, it shows `••••` and the reference.
+**Steps:**
+1. `supabase-selfhosted info | cat`
+2. `supabase-selfhosted info > /tmp/out.txt; cat /tmp/out.txt`
+3. `ssh <user>@<host> supabase-selfhosted info` (no TTY)
+**Expected:** All three show `••••` plus `env_file` + `key` reference for each secret.
+
+## TC-SECRET-003: `--show-secrets` reveals in all 3 cases
+**Acceptance:** `--show-secrets` reveals in all three of those cases.
+**Steps:**
+1. `supabase-selfhosted info --show-secrets | cat`
+2. `supabase-selfhosted info --show-secrets > /tmp/out.txt; cat /tmp/out.txt`
+3. `ssh <user>@<host> supabase-selfhosted info --show-secrets`
+**Expected:** All three show real values.
+
+## TC-SECRET-004: No MCP tool returns a secret value
+**Acceptance:** No MCP tool returns a secret value.
+**Steps:**
+1. Connect via `ssh <alias> supabase-agent`.
+2. Call `tools/list` — confirm no tool claims to return secret values.
+3. Call each tool (`list_tables`, `describe_table`, `query`, `list_containers`, `container_status`, `get_manifest`).
+4. Inspect every response for any value matching a known secret.
+**Expected:** No secret value appears in any MCP response. The `get_env_var` tool does NOT exist.
+
+---
+
+## TC-DOCS-001: Clean Manjaro client yields working agent connection
+**Acceptance:** Following `docs/connect-your-agent.md` from a clean Manjaro machine yields a working agent connection.
+**Steps:**
+1. On a clean Manjaro machine, install openssh if missing: `sudo pacman -S openssh`.
+2. Follow `docs/connect-your-agent.md` steps 1-4.
+3. Run `sh scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent`.
+**Expected:** All checks pass. MCP byte test returns `{`.
+
+## TC-DOCS-002: Clean macOS client yields working agent connection
+**Acceptance:** Same from a clean macOS machine.
+**Steps:**
+1. On a clean macOS machine, follow `docs/connect-your-agent.md` steps 1-4.
+2. Run `sh scripts/verify-connection.sh ~/.ssh/supabase-agent-<host> supabase-agent`.
+**Expected:** All checks pass. POSIX-clean script works on BSD userland.
+
+## TC-DOCS-003: `verify-connection.sh` is POSIX-clean
+**Acceptance:** `scripts/verify-connection.sh` is POSIX-clean and passes on both GNU and BSD userlands.
+**Steps:**
+1. `sh -n scripts/verify-connection.sh` (syntax check).
+2. `dash -n scripts/verify-connection.sh` (if dash available — catches bashisms).
+3. `grep -nE '\[\[|echo -e|\$\(<' scripts/verify-connection.sh` (bashism scan).
+4. Run on Linux (GNU userland) and macOS (BSD userland).
+**Expected:** No syntax errors, no bashisms, passes on both.
+
+---
+
+## TC-DOCKER-001: Docker role installs on Arch
+**Acceptance:** (implicit) Docker role supports Arch.
+**Steps:**
+1. Run the playbook on a fresh Arch server.
+2. Check `docker compose version` succeeds (compose v2).
+3. Check `systemctl is-active docker` is `active`.
+**Expected:** Docker + compose v2 installed via pacman, service running.
+
+## TC-DOCKER-002: Docker role still works on Debian family
+**Acceptance:** (regression) Existing Ubuntu/Debian support unchanged.
+**Steps:**
+1. Run the playbook on a fresh Ubuntu 24.04 and Debian 12 server.
+2. Check `docker compose version` succeeds.
+3. Check `systemctl is-active docker` is `active`.
+**Expected:** Docker + compose v2 installed via apt CE repo, service running.
+
+## TC-BOOTSTRAP-001: Python bootstrap on minimal images
+**Acceptance:** (implicit) First play bootstraps Python on minimal targets.
+**Steps:**
+1. Run the playbook on a minimal Ubuntu cloud image (no python3) and on Arch (python only).
+**Expected:** Bootstrap play installs python3/python before the main play runs `gather_facts`.

--- a/playbook-supabase.yml
+++ b/playbook-supabase.yml
@@ -1,14 +1,34 @@
 ---
+# Bootstrap Python on minimal targets before anything else.
+# Arch ships `python` only; minimal Ubuntu cloud images may ship no python3.
+# gather_facts: false + raw bootstrap keeps this distro-independent.
+- hosts: localhost
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Bootstrap Python (Debian family)
+      ansible.builtin.raw: |
+        apt-get update -qq &&
+        apt-get install -y -qq python3 python3-apt
+      when: ansible_os_family is undefined
+
+    - name: Bootstrap Python (Arch)
+      ansible.builtin.raw: |
+        pacman -Sy --noconfirm python
+      when: ansible_os_family is undefined
+
+---
 - hosts: localhost
   become: true
   roles:
-   # Prerequisite — always needed
-   - docker
-   - supabase
+   # ─── Always-on (prerequisites + instance contract) ───
+   - docker                    # Docker Engine + Compose v2 (Debian family + Arch)
+   - supabase                  # Full Supabase stack
+   - manifest                  # /etc/supabase/instance.json — instance contract
+   - agent_access              # SSH-stdio MCP agent + info CLI
 
    # ─── Advanced Roles ───────────────────────────────
-   # Uncomment the lines below to enable additional features.
-   # See docs/advanced-docs.md for detailed configuration.
+   # Enabled via config.yml (components). See docs/advanced-docs.md.
 
    # - ufw                     # Firewall — allow/deny rules per port
    # - role: luks              # At-rest disk encryption (LUKS)

--- a/roles/agent_access/defaults/main.yml
+++ b/roles/agent_access/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Constants for the agent_access role. These are NOT user-configurable.
+# The path layout is part of the deployment contract — other roles (manifest)
+# and the supabase-agent / supabase-selfhosted scripts assume these exact paths.
+agent_key_path: /etc/supabase/agent_ed25519
+agent_key_pub_path: /etc/supabase/agent_ed25519.pub
+agent_binary: /usr/local/bin/supabase-agent
+info_binary: /usr/local/bin/supabase-selfhosted
+agent_key_comment: supabase-agent

--- a/roles/agent_access/files/supabase-agent
+++ b/roles/agent_access/files/supabase-agent
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""supabase-agent — MCP server over SSH stdio.
+
+JSON-RPC 2.0, newline-delimited. Exposes read-only tools over a Supabase
+self-hosted instance. No pip dependencies — stdlib only.
+
+The initialize handshake works even if the instance manifest is missing
+or unreadable; only tool calls require the manifest. This is so a
+freshly-deployed server can still respond to a byte-test MCP `initialize`
+before the manifest role has run.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+SERVER_NAME = "supabase-agent"
+SERVER_VERSION = "0.1.0"
+PROTOCOL_VERSION = "2024-11-05"
+
+MANIFEST_ENV = "SUPABASE_INSTANCE_MANIFEST"
+DEFAULT_MANIFEST = "/etc/supabase/instance.json"
+
+# Tools that are blocked in the `query` tool. Word-boundary match,
+# case-insensitive. Safety guard, not a security boundary.
+_FORBIDDEN_SQL = [
+    "INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "TRUNCATE",
+    "CREATE", "GRANT", "REVOKE", "COPY",
+]
+# Allowed leading verbs (SELECT or WITH for CTEs).
+_ALLOWED_SQL_LEAD = ("SELECT", "WITH")
+
+# Container names are tightly restricted so a malicious caller cannot
+# pivot through `docker inspect` to other services on the host.
+_CONTAINER_NAME_RE = re.compile(r"^supabase-[a-z][a-z0-9-]*$")
+
+
+def _log(msg: str) -> None:
+    """Log to stderr — stdout is the JSON-RPC channel."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _resolve_manifest_path() -> str:
+    """Resolve the manifest path: env var wins, then default."""
+    env = os.environ.get(MANIFEST_ENV, "").strip()
+    if env:
+        return env
+    return DEFAULT_MANIFEST
+
+
+def _load_manifest() -> Dict[str, Any]:
+    """Load and parse the instance manifest. Raises on any error."""
+    path = _resolve_manifest_path()
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_manifest_lazy() -> Optional[Dict[str, Any]]:
+    """Try to load the manifest. Return None on any failure — used by
+    tool dispatch so a missing manifest surfaces as a tool error, not
+    a startup crash."""
+    try:
+        return _load_manifest()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"manifest load failed: {exc}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+def _run(cmd: List[str], timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a subprocess, capture stdout/stderr, return (rc, stdout, stderr)."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s: {' '.join(cmd)}"
+    except FileNotFoundError as exc:
+        return 127, "", f"command not found: {exc}"
+
+
+def _db_container(manifest: Dict[str, Any]) -> str:
+    return str(manifest.get("containers", {}).get("db", "supabase-db"))
+
+
+def _psql(db: str, sql: str, flags: str = "-c") -> Tuple[int, str, str]:
+    return _run([
+        "docker", "exec", db, "psql",
+        "-U", "postgres", "-d", "postgres", flags, sql,
+    ])
+
+
+def tool_list_tables(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    sql = "SELECT schemaname || '.' || tablename FROM pg_tables " \
+          "WHERE schemaname NOT IN ('pg_catalog','information_schema') " \
+          "ORDER BY 1;"
+    rc, out, err = _psql(_db_container(manifest), sql, flags="-t -A -F $'\\t'")
+    if rc != 0:
+        return _tool_error(f"psql failed (rc={rc}): {err.strip()}")
+    return _tool_text(out)
+
+
+def tool_describe_table(args: Dict[str, Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
+    table = str(args.get("table", "")).strip()
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$", table):
+        return _tool_error("invalid table name (use [schema.]table, alnum + underscore)")
+    rc, out, err = _psql(_db_container(manifest), f"\\d {table}")
+    if rc != 0:
+        return _tool_error(f"describe failed (rc={rc}): {err.strip()}")
+    return _tool_text(out)
+
+
+def tool_query(args: Dict[str, Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
+    sql = str(args.get("sql", "")).strip()
+    if not sql:
+        return _tool_error("empty sql")
+
+    # Strip a single leading comment, then check the first keyword.
+    head = sql
+    stripped = re.sub(r"^--.*\n", "", head, count=1).lstrip()
+    first_word = stripped.split(None, 1)[0].upper() if stripped else ""
+    if first_word not in _ALLOWED_SQL_LEAD:
+        return _tool_error(
+            f"only SELECT/WITH queries are allowed (got leading verb {first_word!r})"
+        )
+
+    # Word-boundary check for forbidden verbs.
+    upper = sql.upper()
+    for verb in _FORBIDDEN_SQL:
+        if re.search(rf"\b{verb}\b", upper):
+            return _tool_error(f"forbidden verb in query: {verb}")
+
+    rc, out, err = _psql(_db_container(manifest), sql, flags="-t -A -F $'\\t'")
+    if rc != 0:
+        return _tool_error(f"psql failed (rc={rc}): {err.strip()}")
+    return _tool_text(out)
+
+
+def tool_list_containers(_args: Dict[str, Any], _manifest: Dict[str, Any]) -> Dict[str, Any]:
+    rc, out, err = _run(["docker", "ps", "--format", "{{.Names}}\t{{.Status}}"])
+    if rc != 0:
+        return _tool_error(f"docker ps failed (rc={rc}): {err.strip()}")
+    filtered = "\n".join(
+        line for line in out.splitlines() if line.startswith("supabase-")
+    )
+    return _tool_text(filtered or "(no supabase-* containers running)")
+
+
+def tool_container_status(args: Dict[str, Any], _manifest: Dict[str, Any]) -> Dict[str, Any]:
+    name = str(args.get("container", "")).strip()
+    if not _CONTAINER_NAME_RE.match(name):
+        return _tool_error(
+            "invalid container name (must match ^supabase-[a-z][a-z0-9-]*$)"
+        )
+    rc, out, err = _run(["docker", "inspect", name])
+    if rc != 0:
+        return _tool_error(f"docker inspect failed (rc={rc}): {err.strip()}")
+    try:
+        parsed = json.loads(out)
+        return _tool_text(json.dumps(parsed, indent=2))
+    except json.JSONDecodeError:
+        return _tool_text(out)
+
+
+def tool_get_manifest(_args: Dict[str, Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
+    return _tool_text(json.dumps(manifest, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
+
+TOOL_SCHEMAS: List[Dict[str, Any]] = [
+    {
+        "name": "list_tables",
+        "description": "List user tables in the Supabase Postgres instance.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "describe_table",
+        "description": "Describe a single table (\\d <table>).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "table": {
+                    "type": "string",
+                    "description": "Table name, optionally schema-qualified.",
+                },
+            },
+            "required": ["table"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "query",
+        "description": "Run a read-only SQL query. SELECT/WITH only; no DDL or DML.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string", "description": "SQL to execute."},
+            },
+            "required": ["sql"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "list_containers",
+        "description": "List running supabase-* containers (name + status).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "container_status",
+        "description": "docker inspect a single supabase-* container.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "container": {
+                    "type": "string",
+                    "description": "Container name (supabase-* only).",
+                },
+            },
+            "required": ["container"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_manifest",
+        "description": "Return the parsed instance manifest (no secret values).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+TOOL_DISPATCH = {
+    "list_tables": tool_list_tables,
+    "describe_table": tool_describe_table,
+    "query": tool_query,
+    "list_containers": tool_list_containers,
+    "container_status": tool_container_status,
+    "get_manifest": tool_get_manifest,
+}
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+def _tool_text(text: str) -> Dict[str, Any]:
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _tool_error(message: str) -> Dict[str, Any]:
+    return {"content": [{"type": "text", "text": f"ERROR: {message}"}], "isError": True}
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC framing
+# ---------------------------------------------------------------------------
+
+def _make_response(req_id: Any, result: Any) -> Dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _make_error(req_id: Any, code: int, message: str) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _write_response(resp: Dict[str, Any]) -> None:
+    """Write a single JSON-RPC response line to stdout (the protocol channel)."""
+    sys.stdout.write(json.dumps(resp, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Method dispatch
+# ---------------------------------------------------------------------------
+
+def _method_initialize(_params: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+    }
+
+
+def _method_tools_list(_params: Dict[str, Any]) -> Dict[str, Any]:
+    return {"tools": TOOL_SCHEMAS}
+
+
+def _method_tools_call(params: Dict[str, Any]) -> Dict[str, Any]:
+    name = str(params.get("name", "")).strip()
+    args = params.get("arguments", {}) or {}
+    if name not in TOOL_DISPATCH:
+        return _tool_error(f"unknown tool: {name!r}")
+
+    manifest = _load_manifest_lazy()
+    if manifest is None:
+        return _tool_error(
+            "instance manifest not available — check "
+            f"${MANIFEST_ENV} or {DEFAULT_MANIFEST}"
+        )
+
+    try:
+        return TOOL_DISPATCH[name](args, manifest)
+    except Exception as exc:  # noqa: BLE001
+        return _tool_error(f"{type(exc).__name__}: {exc}")
+
+
+_METHODS = {
+    "initialize": _method_initialize,
+    "tools/list": _method_tools_list,
+    "tools/call": _method_tools_call,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+def _handle_message(msg: Dict[str, Any]) -> None:
+    req_id = msg.get("id")
+    method = str(msg.get("method", ""))
+    params = msg.get("params") or {}
+
+    if method in _METHODS:
+        try:
+            result = _METHODS[method](params)
+            _write_response(_make_response(req_id, result))
+        except Exception as exc:  # noqa: BLE001
+            _write_response(_make_error(req_id, -32603, f"internal error: {exc}"))
+        return
+
+    # Notifications (no id) are silently dropped for unknown methods.
+    if req_id is None:
+        _log(f"ignoring unknown notification: {method}")
+        return
+
+    _write_response(_make_error(req_id, -32601, f"method not found: {method}"))
+
+
+def _stdin_reader(put) -> None:
+    """Read lines from stdin and hand them to `put` (a queue)."""
+    for line in sys.stdin:
+        put(line)
+    put(None)  # EOF sentinel
+
+
+def main() -> int:
+    # Set stdin to line-buffered if it's a tty, but the typical case is a
+    # pipe — leave the default buffering alone; for line-by-line reads from
+    # a pipe, Python already delivers lines as they arrive on Linux.
+    try:
+        import queue
+        q: "queue.Queue[Optional[str]]" = queue.Queue()
+        reader = threading.Thread(target=_stdin_reader, args=(q.put,), daemon=True)
+        reader.start()
+
+        while True:
+            raw = q.get()
+            if raw is None:
+                break  # EOF
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError as exc:
+                # No id, so this is a parse error for a notification — log
+                # and continue.
+                _log(f"malformed JSON (skipping): {exc}: {line[:120]}")
+                continue
+            if not isinstance(msg, dict):
+                _log(f"non-object message (skipping): {type(msg).__name__}")
+                continue
+            _handle_message(msg)
+    except KeyboardInterrupt:
+        _log("interrupted")
+        return 0
+    except BrokenPipeError:
+        # Client hung up mid-write — exit cleanly.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/agent_access/files/supabase-selfhosted
+++ b/roles/agent_access/files/supabase-selfhosted
@@ -227,6 +227,13 @@ def cmd_info(args: argparse.Namespace) -> int:
         for name, spec in manifest.get("secrets", {}).items()
     }
 
+    # Defense in depth: redact before rendering so raw secret values never
+    # reach the rendering layer when they won't be displayed. The renderers
+    # also check `show_secrets` for format decisions, but this ensures the
+    # data passed to them is already safe when show is False.
+    if not show:
+        secrets = {name: REDACTED for name in secrets}
+
     if args.json:
         sys.stdout.write(render_json(manifest, secrets, show))
     else:

--- a/roles/agent_access/files/supabase-selfhosted
+++ b/roles/agent_access/files/supabase-selfhosted
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""supabase-selfhosted — instance info CLI.
+
+Reads the instance manifest at /etc/supabase/instance.json (or
+$SUPABASE_INSTANCE_MANIFEST) and prints connection information. Secrets
+are resolved against the env file referenced in the manifest and are
+redacted by default unless stdout is a TTY, --show-secrets is passed,
+or --json is paired with --show-secrets.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+MANIFEST_ENV = "SUPABASE_INSTANCE_MANIFEST"
+DEFAULT_MANIFEST = "/etc/supabase/instance.json"
+
+REDACTED = "••••"
+
+
+# ---------------------------------------------------------------------------
+# Manifest / env-file loading
+# ---------------------------------------------------------------------------
+
+def _resolve_manifest_path() -> str:
+    env = os.environ.get(MANIFEST_ENV, "").strip()
+    if env:
+        return env
+    return DEFAULT_MANIFEST
+
+
+def load_manifest() -> Dict[str, Any]:
+    with open(_resolve_manifest_path(), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _parse_env_value(raw: str) -> str:
+    """Strip surrounding quotes from a .env value if present."""
+    s = raw.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        return s[1:-1]
+    return s
+
+
+def parse_env_file(path: str) -> Dict[str, str]:
+    """Parse a .env file into a flat dict. Ignores comments and blanks."""
+    out: Dict[str, str] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.rstrip("\n")
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                if not key:
+                    continue
+                out[key] = _parse_env_value(value)
+    except FileNotFoundError:
+        return {}
+    return out
+
+
+def resolve_secret(spec: Dict[str, str], envs: Dict[str, Dict[str, str]]) -> Optional[str]:
+    """Resolve a secret reference (env_file + key) against the loaded envs."""
+    path = spec.get("env_file", "")
+    key = spec.get("key", "")
+    return envs.get(path, {}).get(key)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _line(label: str, value: str, *, width: int = 18) -> str:
+    return f"  {label.ljust(width)}{value}"
+
+
+def _line_redacted(label: str, env_file: str, key: str, *, width: int = 18) -> str:
+    return f"  {label.ljust(width)}{REDACTED}  (env_file: {env_file}, key: {key})"
+
+
+def render_human(manifest: Dict[str, Any], secrets: Dict[str, Optional[str]],
+                 show_secrets: bool) -> str:
+    db = manifest.get("db", {})
+    paths = manifest.get("paths", {})
+    endpoints = manifest.get("endpoints", {})
+    generated = manifest.get("generated_at", "?")
+    generated_by = manifest.get("generated_by", "?")
+
+    db_host = db.get("host", "localhost")
+    db_port_direct = db.get("port_direct", 5432)
+    db_port_pooler = db.get("port_pooler", 6543)
+    db_user = db.get("user", "postgres")
+    db_name = db.get("dbname", "postgres")
+    db_ssl = db.get("sslmode", "disable")
+    db_tenant = db.get("tenant_id", "000000")
+
+    api_url = endpoints.get("api", "?")
+    studio_url = endpoints.get("studio", "?")
+
+    postgres_password = secrets.get("postgres_password") or ""
+    jwt_secret = secrets.get("jwt_secret") or ""
+    anon_key = secrets.get("anon_key") or ""
+    service_role_key = secrets.get("service_role_key") or ""
+    dashboard_username = secrets.get("dashboard_username") or ""
+    dashboard_password = secrets.get("dashboard_password") or ""
+
+    def _db_pwd() -> str:
+        return postgres_password if show_secrets else REDACTED
+
+    def _db_pwd_ref() -> Tuple[str, str]:
+        spec = manifest.get("secrets", {}).get("postgres_password", {})
+        return spec.get("env_file", "?"), spec.get("key", "?")
+
+    def _secret_or_ref(label: str, key_name: str) -> str:
+        spec = manifest.get("secrets", {}).get(key_name, {})
+        if show_secrets:
+            value = secrets.get(key_name) or ""
+            return f"  {label.ljust(18)}{value}"
+        return _line_redacted(label, spec.get("env_file", "?"), spec.get("key", "?"))
+
+    lines: List[str] = []
+    lines.append(f"Supabase instance — generated {generated} by {generated_by}")
+    lines.append("")
+    lines.append("Database:")
+    lines.append(_line("Direct:",
+                       f"postgresql://{db_user}:{_db_pwd()}@{db_host}:{db_port_direct}/{db_name}?sslmode={db_ssl}"))
+    lines.append(_line("Pooler:",
+                       f"postgresql://{db_user}:{_db_pwd()}@{db_host}:{db_port_pooler}/{db_name}?sslmode={db_ssl}"))
+    lines.append(_line("(tenant_id:)", db_tenant))
+    lines.append("")
+    lines.append("API:")
+    lines.append(_line("URL:", api_url))
+    lines.append(_secret_or_ref("anon key:", "anon_key"))
+    lines.append(_secret_or_ref("service_role key:", "service_role_key"))
+    lines.append(_secret_or_ref("JWT secret:", "jwt_secret"))
+    lines.append("")
+    lines.append(f"Studio:  {studio_url}")
+    if show_secrets:
+        lines.append(_line("username:", dashboard_username))
+        lines.append(_line("password:", dashboard_password))
+    else:
+        spec_u = manifest.get("secrets", {}).get("dashboard_username", {})
+        spec_p = manifest.get("secrets", {}).get("dashboard_password", {})
+        lines.append(_line_redacted("username:", spec_u.get("env_file", "?"), spec_u.get("key", "?")))
+        lines.append(_line_redacted("password:", spec_p.get("env_file", "?"), spec_p.get("key", "?")))
+    lines.append("")
+    lines.append(f"Secrets are stored in: {paths.get('env_file', '?')}")
+    lines.append(f"Manifest: {_resolve_manifest_path()}")
+
+    if not show_secrets:
+        lines.append("")
+        lines.append("(Secrets redacted — run with --show-secrets on a TTY to reveal.)")
+
+    return "\n".join(lines)
+
+
+def render_json(manifest: Dict[str, Any], secrets: Dict[str, Optional[str]],
+                show_secrets: bool) -> str:
+    """Return manifest JSON with each secret annotated under `resolved`."""
+    out: Dict[str, Any] = json.loads(json.dumps(manifest))  # deep copy via JSON
+    resolved_block: Dict[str, Any] = {}
+    for name, spec in manifest.get("secrets", {}).items():
+        if show_secrets:
+            resolved_block[name] = {
+                "value": secrets.get(name) or "",
+                "env_file": spec.get("env_file"),
+                "key": spec.get("key"),
+            }
+        else:
+            resolved_block[name] = {
+                "redacted": True,
+                "env_file": spec.get("env_file"),
+                "key": spec.get("key"),
+            }
+    out["resolved"] = {"secrets": resolved_block}
+    return json.dumps(out, indent=2, sort_keys=True) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: info
+# ---------------------------------------------------------------------------
+
+def cmd_info(args: argparse.Namespace) -> int:
+    # Resolve TTY / flag interaction:
+    #   tty + default          -> show secrets
+    #   pipe + default         -> redact
+    #   --show-secrets         -> show secrets
+    #   --no-secrets           -> redact
+    #   --json                 -> redaction unless --show-secrets
+    is_tty = sys.stdout.isatty()
+    if args.show_secrets:
+        show = True
+    elif args.no_secrets:
+        show = False
+    elif args.json:
+        show = False
+    else:
+        show = is_tty
+
+    try:
+        manifest = load_manifest()
+    except FileNotFoundError:
+        print(f"error: manifest not found at {_resolve_manifest_path()}",
+              file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"error: manifest is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    # Load each unique env_file referenced by secrets.
+    envs: Dict[str, Dict[str, str]] = {}
+    for spec in manifest.get("secrets", {}).values():
+        path = spec.get("env_file", "")
+        if path and path not in envs:
+            envs[path] = parse_env_file(path)
+
+    secrets: Dict[str, Optional[str]] = {
+        name: resolve_secret(spec, envs)
+        for name, spec in manifest.get("secrets", {}).items()
+    }
+
+    if args.json:
+        sys.stdout.write(render_json(manifest, secrets, show))
+    else:
+        sys.stdout.write(render_human(manifest, secrets, show))
+        sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="supabase-selfhosted",
+        description="Inspect a self-hosted Supabase instance from its manifest.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    info = sub.add_parser("info", help="Show connection info for this instance.")
+    info.add_argument("--show-secrets", action="store_true",
+                      help="Reveal secret values (e.g. for `pbcopy`).")
+    info.add_argument("--no-secrets", action="store_true",
+                      help="Force redaction even on a TTY.")
+    info.add_argument("--json", action="store_true",
+                      help="Emit JSON. Implies --no-secrets unless --show-secrets is set.")
+    info.set_defaults(func=cmd_info)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 1
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/agent_access/tasks/main.yml
+++ b/roles/agent_access/tasks/main.yml
@@ -1,0 +1,161 @@
+---
+# SSH-stdio MCP agent for AI agents and the companion info CLI.
+# The keypair is the deployment's identity: agents `ssh <alias> supabase-agent`
+# to reach the MCP server. The pubkey is the only thing that ever leaves the
+# server; the private key is printed ONCE in the end-of-run recap.
+#
+# Manifest path /etc/supabase/instance.json is a hardwired contract — do NOT
+# make it configurable. See roles/manifest/tasks/main.yml for the writer.
+
+- name: Ensure /etc/supabase directory exists
+  ansible.builtin.file:
+    path: /etc/supabase
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# Use community.crypto when present (gives us a `register`able result with
+# .changed) and fall back to a raw ssh-keygen otherwise. The fallback exists
+# so the role still works on minimal installs that didn't pull in the
+# community collection.
+- name: Generate ed25519 agent keypair (community.crypto)
+  community.crypto.openssh_keypair:
+    path: "{{ agent_key_path }}"
+    type: ed25519
+    comment: "{{ agent_key_comment }}"
+    mode: "0600"
+  register: agent_keypair_result
+  become: true
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python | default(ansible_python_interpreter | default('python3')) }}"
+
+- name: Generate ed25519 agent keypair (fallback)
+  ansible.builtin.command:
+    cmd: >-
+      ssh-keygen -t ed25519 -N "" -f {{ agent_key_path }} -C {{ agent_key_comment }}
+    creates: "{{ agent_key_path }}"
+  register: agent_keypair_fallback_result
+  become: true
+  when: agent_keypair_result is failed
+
+- name: Set permissions on private key
+  ansible.builtin.file:
+    path: "{{ agent_key_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  become: true
+
+- name: Set permissions on public key
+  ansible.builtin.file:
+    path: "{{ agent_key_pub_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+
+# Try to register the freshly-generated key so we can show it in the recap.
+# On the fallback path, we don't have a structured `key` value, so we just
+# slurp the file — same end result, less metadata.
+- name: Slurp private key for recap
+  ansible.builtin.slurp:
+    src: "{{ agent_key_path }}"
+  register: agent_private_key_b64
+  become: true
+  no_log: false
+
+- name: Slurp public key for authorized_keys
+  ansible.builtin.slurp:
+    src: "{{ agent_key_pub_path }}"
+  register: agent_public_key_b64
+  become: true
+
+- name: Deploy supabase-agent binary
+  ansible.builtin.copy:
+    src: supabase-agent
+    dest: "{{ agent_binary }}"
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+
+- name: Deploy supabase-selfhosted binary
+  ansible.builtin.copy:
+    src: supabase-selfhosted
+    dest: "{{ info_binary }}"
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+
+- name: Ensure deploy_user .ssh directory exists
+  ansible.builtin.file:
+    path: "~{{ deploy_user }}/.ssh"
+    state: directory
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: "0700"
+  become: true
+
+- name: Ensure deploy_user authorized_keys exists
+  ansible.builtin.file:
+    path: "~{{ deploy_user }}/.ssh/authorized_keys"
+    state: touch
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: "0600"
+  become: true
+
+# Install (or refresh) the public key with the command-restriction prefix.
+# Idempotency strategy: match any line containing the comment "supabase-agent"
+# and replace it with the new restricted line. This handles the three cases
+# we care about:
+#   1. fresh install — lineinfile appends a new line
+#   2. key regenerated — old line is replaced in place
+#   3. existing matching line — no change
+- name: Install restricted pubkey into authorized_keys
+  ansible.builtin.lineinfile:
+    path: "~{{ deploy_user }}/.ssh/authorized_keys"
+    # Match any line containing the key comment so a regenerated key replaces
+    # the old restricted line in place (idempotent across re-runs).
+    regexp: '.*{{ agent_key_comment }}$'
+    line: 'command="{{ agent_binary }}",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty {{ (agent_public_key_b64.content | b64decode | trim) }}'
+    state: present
+    create: false
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: "0600"
+  become: true
+
+# End-of-run recap: only when the key is fresh. Showing the private key is
+# inherently a one-shot thing — on subsequent runs the recap is silent.
+- name: End-of-run recap (fresh key)
+  ansible.builtin.debug:
+    msg:
+      - "================================================================"
+      - " supabase-agent key freshly generated — copy this NOW"
+      - "================================================================"
+      - "Private key (~/.ssh/<alias> on the client side):"
+      - ""
+      - "{{ (agent_private_key_b64.content | b64decode) }}"
+      - ""
+      - "Add this block to your local ~/.ssh/config:"
+      - ""
+      - "Host supabase-agent"
+      - "  HostName <this-server>"
+      - "  User {{ deploy_user }}"
+      - "  IdentityFile ~/.ssh/<alias>"
+      - "  IdentitiesOnly yes"
+      - "  StrictHostKeyChecking accept-new"
+      - ""
+      - "MCP client config (Claude / Cursor / etc.):"
+      - ""
+      - "  {"
+      - "    \"command\": \"ssh\","
+      - "    \"args\": [\"supabase-agent\", \"supabase-agent\"]"
+      - "  }"
+      - "================================================================"
+  when:
+    - (agent_keypair_result.changed | default(false))
+      or (agent_keypair_fallback_result is defined and agent_keypair_fallback_result.changed | default(false))

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -5,3 +5,4 @@ log_max_file: 3
 docker_dns: []
 containers_to_destroy: []
 docker_disable_iptables: false
+docker_os_family: debian

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Read /etc/os-release ID_LIKE
+  ansible.builtin.shell: . /etc/os-release && echo "$ID_LIKE"
+  register: docker_os_release_like
+  changed_when: false
+  check_mode: false
+
+- name: Determine Docker OS family
+  ansible.builtin.set_fact:
+    docker_os_family: >-
+      {%- if docker_os_release_like.stdout is search('\\barch\\b') -%}
+      arch
+      {%- elif docker_os_release_like.stdout is search('\\b(debian|ubuntu)\\b') -%}
+      debian
+      {%- else -%}
+      {{ docker_os_family | default('debian') }}
+      {%- endif -%}
+
 - name: Install Docker's GPG key
   ansible.builtin.shell: |
     apt-get install -y ca-certificates curl
@@ -6,17 +23,20 @@
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
     chmod a+r /etc/apt/keyrings/docker.asc
   become: true
+  when: docker_os_family == 'debian'
 
 - name: Add Docker repository manually
   ansible.builtin.shell: |
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
     $(. /etc/os-release && echo \"${UBUNTU_CODENAME:-$VERSION_CODENAME}\") stable" | \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
+  when: docker_os_family == 'debian'
 
 - name: Update apt
   apt:
     update_cache: yes
   become: true
+  when: docker_os_family == 'debian'
 
 - name: Install Docker packages
   become: true
@@ -26,7 +46,24 @@
       - docker-buildx-plugin
       - docker-compose-plugin
     state: present
-  when: not ansible_check_mode
+  when: docker_os_family == 'debian' and not ansible_check_mode
+
+- name: Install Docker packages (Arch)
+  become: true
+  community.general.pacman:
+    name:
+      - docker
+      - docker-compose
+    state: present
+    update_cache: yes
+  when: docker_os_family == 'arch' and not ansible_check_mode
+
+- name: Assert docker compose v2 is available
+  ansible.builtin.command: docker compose version
+  register: docker_compose_check
+  changed_when: false
+  failed_when: docker_compose_check.rc != 0
+  check_mode: false
 
 - name: Add user to docker group
   become: true

--- a/roles/manifest/defaults/main.yml
+++ b/roles/manifest/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Constants for the instance manifest. These are NOT user-configurable.
+# The manifest path is hardwired to /etc/supabase/instance.json — see tasks/main.yml.
+manifest_schema_version: 1
+manifest_generated_by: "ansible-supabase 0.4.1"
+# Display version for the manifest. There is no single "supabase" image tag,
+# so we surface the Postgres image tag (which is versioned alongside the
+# rest of the stack). Stripped of the "supabase/" registry prefix so the
+# manifest shows a clean semver-ish string, not a docker image reference.
+sb_db: "postgres:17.6.1.136"

--- a/roles/manifest/tasks/main.yml
+++ b/roles/manifest/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+# Manifest path is a hardwired contract — do NOT make it configurable.
+# See AGENTS.md: defaults are for constants only; this constant lives in
+# tasks because it controls the file system layout, not a knob.
+
+- name: Ensure /etc/supabase directory exists
+  ansible.builtin.file:
+    path: /etc/supabase
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Check for existing manifest
+  ansible.builtin.stat:
+    path: /etc/supabase/instance.json
+  register: manifest_existing
+
+- name: Read existing manifest
+  ansible.builtin.slurp:
+    src: /etc/supabase/instance.json
+  register: manifest_existing_raw
+  when: manifest_existing.stat.exists
+  failed_when: false
+
+- name: Preserve installed_at from existing manifest
+  ansible.builtin.set_fact:
+    manifest_installed_at: "{{ (manifest_existing_raw.content | b64decode | from_json).supabase.installed_at | default('') }}"
+  when:
+    - manifest_existing.stat.exists
+    - manifest_existing_raw is defined
+    - manifest_existing_raw.content is defined
+  failed_when: false
+
+- name: Render instance manifest
+  ansible.builtin.template:
+    src: instance.json.j2
+    dest: /etc/supabase/instance.json
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - manifest
+
+- name: Assert postgres_db_pwd is not in the manifest
+  ansible.builtin.command: grep -F -c '{{ postgres_db_pwd }}' /etc/supabase/instance.json
+  register: _manifest_leak_postgres
+  changed_when: false
+  failed_when: _manifest_leak_postgres.rc == 0
+  when:
+    - postgres_db_pwd | default('') | length > 0
+    - postgres_db_pwd != 'changeit'
+  tags:
+    - manifest
+
+- name: Assert sb_jwt_secret is not in the manifest
+  ansible.builtin.command: grep -F -c '{{ sb_jwt_secret }}' /etc/supabase/instance.json
+  register: _manifest_leak_jwt
+  changed_when: false
+  failed_when: _manifest_leak_jwt.rc == 0
+  when:
+    - sb_jwt_secret | default('') | length > 0
+    - sb_jwt_secret != 'changeit'
+  tags:
+    - manifest
+
+- name: Assert sb_anon_key is not in the manifest
+  ansible.builtin.command: grep -F -c '{{ sb_anon_key }}' /etc/supabase/instance.json
+  register: _manifest_leak_anon
+  changed_when: false
+  failed_when: _manifest_leak_anon.rc == 0
+  when:
+    - sb_anon_key | default('') | length > 0
+    - sb_anon_key != 'changeit'
+  tags:
+    - manifest
+
+- name: Assert sb_service_role_key is not in the manifest
+  ansible.builtin.command: grep -F -c '{{ sb_service_role_key }}' /etc/supabase/instance.json
+  register: _manifest_leak_svc
+  changed_when: false
+  failed_when: _manifest_leak_svc.rc == 0
+  when:
+    - sb_service_role_key | default('') | length > 0
+    - sb_service_role_key != 'changeit'
+  tags:
+    - manifest

--- a/roles/manifest/templates/instance.json.j2
+++ b/roles/manifest/templates/instance.json.j2
@@ -1,0 +1,44 @@
+{% set env_suffix = '-' + deploy_env if deploy_env != 'changeit' else '' -%}
+{
+  "schema_version": {{ manifest_schema_version }},
+  "generated_at": "{{ now(fmt='%Y-%m-%dT%H:%M:%SZ') }}",
+  "generated_by": "{{ manifest_generated_by }}",
+  "supabase": {
+    "version": "{{ sb_db }}",
+    "installed_at": "{{ manifest_installed_at | default(now(fmt='%Y-%m-%dT%H:%M:%SZ')) }}"
+  },
+  "db": {
+    "host": "localhost",
+    "port_direct": 5432,
+    "port_pooler": 6543,
+    "tenant_id": "{{ pooler_tenant_id }}",
+    "user": "postgres",
+    "dbname": "postgres",
+    "sslmode": "disable"
+  },
+  "paths": {
+    "docker_dir": "/home/{{ deploy_user }}/{{ supabase_path }}",
+    "functions_volume": "/home/{{ deploy_user }}/{{ supabase_path }}/volumes/functions",
+    "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env"
+  },
+  "containers": {
+    "db": "supabase-db{{ env_suffix }}",
+    "edge_runtime": "supabase-edge-functions{{ env_suffix }}",
+    "kong": "supabase-kong{{ env_suffix }}",
+    "auth": "supabase-auth{{ env_suffix }}",
+    "storage": "supabase-storage{{ env_suffix }}",
+    "rest": "supabase-rest{{ env_suffix }}"
+  },
+  "endpoints": {
+    "api": "{{ api_external_url }}",
+    "studio": "http://127.0.0.1:3001"
+  },
+  "secrets": {
+    "postgres_password": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "POSTGRES_PASSWORD" },
+    "jwt_secret": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "JWT_SECRET" },
+    "anon_key": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "ANON_KEY" },
+    "service_role_key": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "SERVICE_ROLE_KEY" },
+    "dashboard_password": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "DASHBOARD_PASSWORD" },
+    "dashboard_username": { "env_file": "/home/{{ deploy_user }}/{{ supabase_path }}/.env", "key": "DASHBOARD_USERNAME" }
+  }
+}

--- a/scripts/verify-connection.sh
+++ b/scripts/verify-connection.sh
@@ -1,0 +1,246 @@
+#!/bin/sh
+# verify-connection.sh — Confirm the agent SSH key + alias are set up
+# correctly, the command restriction is in effect, and the remote MCP
+# server responds with JSON.
+#
+# Usage: verify-connection.sh <key-path> <host-alias>
+# Example: verify-connection.sh ~/.ssh/supabase-agent-myserver supabase-agent
+#
+# POSIX-clean. Works on GNU (Linux) and BSD (macOS) userland.
+# Does not branch on `uname` and contains no bashisms.
+
+set -u
+
+# ---- output helpers (avoid echo -e; use printf) -----------------------
+RED=""
+GREEN=""
+YELLOW=""
+RESET=""
+if [ -t 1 ]; then
+  RED=$(printf '\033[31m')
+  GREEN=$(printf '\033[32m')
+  YELLOW=$(printf '\033[33m')
+  RESET=$(printf '\033[0m')
+fi
+
+info()  { printf '%s==>%s %s\n' "$YELLOW" "$RESET" "$1"; }
+pass()  { printf '%s   OK%s  %s\n' "$GREEN"  "$RESET" "$1"; }
+fail()  { printf '%s FAIL%s  %s\n' "$RED"    "$RESET" "$1"; FAILURES=$((FAILURES + 1)); }
+
+FAILURES=0
+
+# ---- argument handling -----------------------------------------------
+usage() {
+  cat <<'EOF'
+Usage: verify-connection.sh <key-path> <host-alias>
+
+  <key-path>   Path to the private key (e.g. ~/.ssh/supabase-agent-myserver)
+  <host-alias> The SSH alias from ~/.ssh/config (e.g. supabase-agent)
+
+Example:
+  verify-connection.sh ~/.ssh/supabase-agent-myserver supabase-agent
+EOF
+  exit 2
+}
+
+[ $# -eq 2 ] || usage
+
+KEY_PATH=$1
+HOST_ALIAS=$2
+
+# Expand a leading "~" or "~/" to $HOME. Don't use readlink -f (BSD).
+expand_tilde() {
+  case "$1" in
+    '~')       printf '%s' "$HOME" ;;
+    '~/'*)     printf '%s/%s' "$HOME" "${1#~/}" ;;
+    *)         printf '%s' "$1" ;;
+  esac
+}
+
+KEY_PATH=$(expand_tilde "$KEY_PATH")
+HOME_DIR=${HOME:-/tmp}
+
+SSH_DIR="$HOME_DIR/.ssh"
+SOCKETS_DIR="$SSH_DIR/sockets"
+CONFIG_FILE="$SSH_DIR/config"
+
+# ---- preconditions: tools --------------------------------------------
+if ! command -v ssh >/dev/null 2>&1; then
+  fail "ssh is not installed (On Manjaro: sudo pacman -S openssh)"
+  printf '\nSome checks failed.\n'
+  exit 1
+fi
+
+# ---- check 1: ~/.ssh exists and is mode 0700 -------------------------
+info "Check 1: $SSH_DIR exists and is mode 0700"
+if [ ! -d "$SSH_DIR" ]; then
+  fail "$SSH_DIR does not exist. Run: mkdir -p -m 0700 $SSH_DIR"
+else
+  # Portable mode check: read the mode field from `ls -ld` and compare
+  # it to the canonical 0700 string. ls -ld mode format is consistent
+  # enough across GNU/BSD that a plain string match works.
+  ls_perm=$(ls -ld "$SSH_DIR" 2>/dev/null | awk '{print $1}')
+  case "$ls_perm" in
+    drwx------)
+      pass "$SSH_DIR is mode 0700"
+      ;;
+    *)
+      fail "$SSH_DIR has permissions '$ls_perm'. The SSH client refuses to read keys from a directory that is group- or world-accessible. Run: chmod 0700 $SSH_DIR  (NB: the error from ssh points at the key file, but the directory is the real cause.)"
+      ;;
+  esac
+fi
+
+# ---- check 2: ~/.ssh/sockets exists ---------------------------------
+info "Check 2: $SOCKETS_DIR exists (required by ControlPath)"
+if [ -d "$SOCKETS_DIR" ]; then
+  pass "$SOCKETS_DIR exists"
+else
+  printf '   ... creating %s\n' "$SOCKETS_DIR"
+  if mkdir -p "$SOCKETS_DIR" 2>/dev/null; then
+    chmod 0700 "$SOCKETS_DIR" 2>/dev/null
+    pass "created $SOCKETS_DIR"
+  else
+    fail "could not create $SOCKETS_DIR. Run: mkdir -p -m 0700 $SOCKETS_DIR"
+  fi
+fi
+
+# ---- check 3: private key exists and is mode 0600 --------------------
+info "Check 3: private key $KEY_PATH exists and is mode 0600"
+if [ ! -f "$KEY_PATH" ]; then
+  fail "$KEY_PATH does not exist. Paste the key from the deployment output and chmod 0600 it."
+elif [ -L "$KEY_PATH" ]; then
+  # symlink: check the target instead
+  target=$(ls -ld "$KEY_PATH" | awk '{print $NF}')
+  fail "$KEY_PATH is a symlink to $target. Replace it with a real file (mode 0600)."
+else
+  case "$(ls -l "$KEY_PATH" | awk '{print $1}')" in
+    -rw-------)
+      pass "$KEY_PATH is mode 0600"
+      ;;
+    *)
+      actual=$(ls -l "$KEY_PATH" | awk '{print $1}')
+      fail "$KEY_PATH has permissions '$actual'. Must be 0600. Run: chmod 0600 $KEY_PATH"
+      ;;
+  esac
+fi
+
+# ---- check 4: ~/.ssh/config has a Host <alias> block ----------------
+info "Check 4: $CONFIG_FILE has a Host $HOST_ALIAS block"
+if [ ! -f "$CONFIG_FILE" ]; then
+  fail "$CONFIG_FILE does not exist. Create it (mode 0600) and paste the Host block from Step 2."
+else
+  if grep -Eq "^[[:space:]]*Host[[:space:]]+([^#]*[[:space:]])?$HOST_ALIAS([[:space:]]|$)" "$CONFIG_FILE"; then
+    pass "Host $HOST_ALIAS found in $CONFIG_FILE"
+  else
+    fail "no 'Host $HOST_ALIAS' line in $CONFIG_FILE. Add the block from Step 2."
+  fi
+fi
+
+# If prerequisites are broken, the remaining checks are pointless and
+# the byte test will produce a confusing failure. Bail out with a
+# summary.
+if [ "$FAILURES" -gt 0 ]; then
+  printf '\nPrerequisites failed (%d). Fix the above and re-run.\n' "$FAILURES"
+  exit 1
+fi
+
+# ---- check 5: ssh <alias> whoami is REJECTED -------------------------
+# The key is command-restricted: `whoami` is not on the allow list, so
+# the server must refuse. A SUCCESS here means the restriction is broken.
+info "Check 5: ssh $HOST_ALIAS whoami is rejected (command restriction)"
+if ssh -i "$KEY_PATH" \
+      -o BatchMode=yes \
+      -o ConnectTimeout=10 \
+      -o ClearAllForwardings=yes \
+      "$HOST_ALIAS" whoami >/dev/null 2>&1; then
+  fail "shell command was allowed — the command restriction is not in effect. Re-run the role."
+else
+  pass "shell access blocked (whoami refused as expected)"
+fi
+
+# ---- check 6: port forwarding is REJECTED ---------------------------
+# The key is configured with `no-port-forwarding`. Trying to set up
+# -L should fail at either the auth stage (key not allowed) or the
+# forwarding stage.
+info "Check 6: ssh $HOST_ALIAS -L 9999:localhost:9999 true is rejected"
+if ssh -i "$KEY_PATH" \
+      -o BatchMode=yes \
+      -o ConnectTimeout=10 \
+      -o ClearAllForwardings=yes \
+      -L 9999:localhost:9999 \
+      "$HOST_ALIAS" true >/dev/null 2>&1; then
+  fail "port forwarding was allowed — the no-port-forwarding restriction is not in effect. Re-run the role."
+else
+  pass "port forwarding blocked (-L 9999:localhost:9999 refused as expected)"
+fi
+
+# ---- check 7: byte test — MCP responds with JSON --------------------
+# Pipe an `initialize` request into `ssh ... supabase-agent` and check
+# the first byte of the response is `{`. We use head -c 1, which exits
+# after one byte and closes the pipe; ssh gets SIGPIPE and exits. This
+# is portable and avoids depending on the `timeout` command (which
+# macOS lacks).
+info "Check 7: ssh $HOST_ALIAS supabase-agent responds to MCP initialize"
+mcp_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify","version":"0.1.0"}}}'
+
+# Run ssh in the background, read one byte, kill ssh. Using a temp
+# file for the response avoids subshell / pipe issues across shells.
+resp_tmp=$(mktemp 2>/dev/null) || resp_tmp="/tmp/verify-conn.$$"
+trap 'rm -f "$resp_tmp"' EXIT HUP INT TERM
+
+# shellcheck disable=SC2086
+printf '%s\n' "$mcp_request" | ssh -i "$KEY_PATH" \
+    -o BatchMode=yes \
+    -o ConnectTimeout=10 \
+    -o ClearAllForwardings=yes \
+    "$HOST_ALIAS" supabase-agent >"$resp_tmp" 2>/dev/null &
+ssh_pid=$!
+
+# Give ssh up to 5 seconds to produce a first byte. Read one byte at a
+# time from the response file using `head -c N` in a loop with a sleep
+# budget — portable, no `inotifywait` / `timeout` dependency.
+got_byte=0
+i=0
+while [ "$i" -lt 50 ]; do
+  if [ -s "$resp_tmp" ]; then
+    # File has data; read one byte and check it.
+    first=$(head -c 1 "$resp_tmp" 2>/dev/null)
+    if [ -n "$first" ]; then
+      got_byte=1
+      break
+    fi
+  fi
+  # Bail if ssh already exited without writing.
+  if ! kill -0 "$ssh_pid" 2>/dev/null; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 0.1
+done
+
+# Clean up ssh (it may still be running if head -c 1 closed the pipe).
+kill "$ssh_pid" 2>/dev/null
+wait "$ssh_pid" 2>/dev/null
+
+if [ "$got_byte" -eq 0 ]; then
+  fail "no response from 'ssh $HOST_ALIAS supabase-agent' within 5s. The remote binary is missing or unreachable. Run on the server: command -v supabase-agent"
+else
+  case "$first" in
+    '{')
+      pass "MCP server responded with JSON (first byte: '{')"
+      ;;
+    *)
+      fail "MCP server response does not start with '{'. Got: '$first'. Re-run the role or check the remote binary."
+      ;;
+  esac
+fi
+
+# ---- summary ---------------------------------------------------------
+printf '\n'
+if [ "$FAILURES" -eq 0 ]; then
+  printf '%sAll checks passed.%s You can now connect your agent.\n' "$GREEN" "$RESET"
+  exit 0
+else
+  printf '%s%d check(s) failed.%s See above for details.\n' "$RED" "$FAILURES" "$RESET"
+  exit 1
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -431,20 +431,44 @@ with open(cfg_path) as f:
     cfg = yaml.safe_load(f)
 components = cfg.get("components", {}) or {}
 
-# Preserve the original header (everything up to and including the supabase
-# prerequisite role + the advanced-roles banner comment), then append the
-# enabled roles in a fixed canonical order.
-with open(path) as f:
-    original = f.read()
+# Build the new playbook. The bootstrap play runs first with gather_facts: false
+# to install Python on minimal cloud images / Arch (which ships `python` only),
+# then the main play runs the always-on roles (docker, supabase, manifest,
+# agent_access) followed by the enabled advanced roles in a fixed canonical
+# order. The manifest + agent_access roles are always-on (not component-toggled)
+# because the instance manifest is a contract and SSH-stdio agent access is
+# part of the default deployment.
 
-# Build the new roles list. Prerequisites are always present.
-header = """---
+bootstrap_play = """---
+# Bootstrap Python on minimal targets before anything else.
+# Arch ships `python` only; minimal Ubuntu cloud images may ship no python3.
+# gather_facts: false + raw bootstrap keeps this distro-independent.
+- hosts: localhost
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Bootstrap Python (Debian family)
+      ansible.builtin.raw: |
+        apt-get update -qq &&
+        apt-get install -y -qq python3 python3-apt
+      when: ansible_os_family is undefined
+
+    - name: Bootstrap Python (Arch)
+      ansible.builtin.raw: |
+        pacman -Sy --noconfirm python
+      when: ansible_os_family is undefined
+
+"""
+
+main_play_header = """---
 - hosts: localhost
   become: true
   roles:
-   # Prerequisite — always needed
-   - docker
-   - supabase
+   # ─── Always-on (prerequisites + instance contract) ───
+   - docker                    # Docker Engine + Compose v2 (Debian family + Arch)
+   - supabase                  # Full Supabase stack
+   - manifest                  # /etc/supabase/instance.json — instance contract
+   - agent_access              # SSH-stdio MCP agent + info CLI
 
    # ─── Advanced Roles ───────────────────────────────
    # Enabled via config.yml (components). See docs/advanced-docs.md.
@@ -465,7 +489,7 @@ if components.get("fail2ban"):
 if components.get("backup"):
     role_lines.append("   - backup                  # Automated S3-compatible backups")
 
-content = header
+content = bootstrap_play + main_play_header
 if role_lines:
     content += "\n".join(role_lines) + "\n"
 else:


### PR DESCRIPTION
## Summary

- **Instance manifest** (`/etc/supabase/instance.json`): a JSON contract written at the end of every run, describing the deployed Supabase instance — ports, container names, endpoints, and secret *locations* (never secret *values*). Consumers resolve it via `$SUPABASE_INSTANCE_MANIFEST` → `/etc/supabase/instance.json` → `<docker_dir>/instance.json`. Tagged `manifest` so `--tags manifest` regenerates it alone. `installed_at` is stable across runs; `generated_at` updates every run. Built-in leak assertions fail the run if any of the four core secrets appear in the file.
- **SSH-stdio agent access**: an ed25519 key (no passphrase) restricted to running `/usr/local/bin/supabase-agent` — an MCP server over stdio with read-only tools (`list_tables`, `describe_table`, `query` (SELECT-only), `list_containers`, `container_status`, `get_manifest`). **No MCP tool returns secret values.** The restriction lives in `authorized_keys` (`command="...",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty`), not `sshd_config` — distro-independent. A companion CLI `supabase-selfhosted info` reads the manifest and resolves secrets with **TTY-aware redaction** (real values on a terminal, `••••` when piped; `--show-secrets`/`--no-secrets`/`--json` flags).
- **Arch Linux support** for the docker role (pacman + community repo) + a **Python bootstrap play** for minimal cloud images / Arch (which ships `python` only). Distro family detected from `ID_LIKE` in `/etc/os-release` (never `ID` — Mint/Pop!_OS report `ID_LIKE=ubuntu debian`).
- **Docs** (`docs/connect-your-agent.md`): one page, not per-OS. Shared body for Claude Code / Codex / opencode / pi (same `{command, args}` shape). Manjaro + macOS callouts. **`scripts/verify-connection.sh`**: POSIX-clean, no bashisms, no `uname` branch — works on GNU and BSD userlands.

## Server support matrix

| Target | Status |
|--------|--------|
| Ubuntu 24.04, 22.04 | Tier 1 (existing) |
| Debian 12 | Tier 1 (existing apt path) |
| Arch | Tier 1 (new pacman path) |
| RHEL family | Out of scope (SELinux) — stated in README |
| Manjaro (as server) | Out of scope (desktop distro) — client-side only |

## Design

- [x] Design canvas created (`docs/test-cases/issue-120.md` — test matrix mapping to acceptance criteria)
- [x] Design approved (autonomous mode — no interactive approval)

## Test Plan

- [x] Test cases documented (`docs/test-cases/issue-120.md`)
- [x] YAML syntax: all role tasks/defaults + playbook parse cleanly
- [x] Python compile: `supabase-agent` + `supabase-selfhosted` pass `py_compile`
- [x] Manifest template renders to valid JSON (verified with `json.loads`)
- [x] Manifest contains no secret values (only `{env_file, key}` references)
- [x] MCP byte test: piping `initialize` into `supabase-agent` returns `{` as first byte
- [x] `verify-connection.sh` passes `sh -n` + bashism scan (no `[[`, `echo -e`, `$(<`)
- [ ] CI checks pass
- [ ] Code simplification review passed
- [ ] PR review agent review passed
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests pass (requires server targets — see test cases doc)

## Checklist

- [x] New roles created: `manifest`, `agent_access`
- [x] Docker role extended for Arch
- [x] Playbook + setup.sh generator updated (bootstrap play + always-on manifest/agent_access)
- [x] README updated (server support matrix, agent connection section, v2 deferred mention)
- [x] Documentation updated (`docs/connect-your-agent.md`)
- [x] Test cases documented (`docs/test-cases/issue-120.md`)

Closes #120