### PR TITLE
fix(setup): single-document playbook and distro-aware Python bootstrap

### DIFF
--- a/playbook-supabase.yml
+++ b/playbook-supabase.yml
@@ -6,18 +6,16 @@
   gather_facts: false
   become: true
   tasks:
-    - name: Bootstrap Python (Debian family)
+    - name: Bootstrap Python (distro-aware)
       ansible.builtin.raw: |
-        apt-get update -qq &&
-        apt-get install -y -qq python3 python3-apt
-      when: ansible_os_family is undefined
+        if [ -x /usr/bin/apt-get ]; then
+          apt-get update -qq && apt-get install -y -qq python3 python3-apt
+        elif [ -x /usr/bin/pacman ]; then
+          pacman -Sy --noconfirm python
+        else
+          exit 1
+        fi
 
-    - name: Bootstrap Python (Arch)
-      ansible.builtin.raw: |
-        pacman -Sy --noconfirm python
-      when: ansible_os_family is undefined
-
----
 - hosts: localhost
   become: true
   roles:

--- a/setup.sh
+++ b/setup.sh
@@ -604,20 +604,18 @@ bootstrap_play = """---
   gather_facts: false
   become: true
   tasks:
-    - name: Bootstrap Python (Debian family)
+    - name: Bootstrap Python (distro-aware)
       ansible.builtin.raw: |
-        apt-get update -qq &&
-        apt-get install -y -qq python3 python3-apt
-      when: ansible_os_family is undefined
-
-    - name: Bootstrap Python (Arch)
-      ansible.builtin.raw: |
-        pacman -Sy --noconfirm python
-      when: ansible_os_family is undefined
-
+        if [ -x /usr/bin/apt-get ]; then
+          apt-get update -qq && apt-get install -y -qq python3 python3-apt
+        elif [ -x /usr/bin/pacman ]; then
+          pacman -Sy --noconfirm python
+        else
+          exit 1
+        fi
 """
 
-main_play_header = """---
+main_play_header = """
 - hosts: localhost
   become: true
   roles:


### PR DESCRIPTION
## What this fixes

Two bugs shipped by the instance-manifest/SSH-agent PR (#123) that break **every** deployment on `main`:

### 1. Playbook fails to parse: duplicate YAML document separator
`setup.sh` concatenates `bootstrap_play` (ends with `\n`) and `main_play_header` (starts with `---`), producing a **second top-level `---`** in the generated playbook. Ansible requires a single YAML document per playbook, so every run died immediately with:

```
Syntax Error while loading YAML.
  but found another document
The offending line appears to be: ---
```

The committed `playbook-supabase.yml` on `main` had the same defect baked in.

**Fix:** removed the `---` from `main_play_header` in the `setup.sh` generator and from the committed playbook. Regeneration and the committed artifact are now single-document (verified: `yaml.safe_load_all` returns exactly 1 document for both).

### 2. Bootstrap play always aborts: both distro branches run on every host
Both bootstrap tasks were gated with `when: ansible_os_family is undefined` — which is **always true** because the play runs with `gather_facts: false` (no facts exist). Result: on Debian/Ubuntu the apt task succeeds and then the `pacman` task fails (and vice versa on Arch), aborting the run before the main play.

**Fix:** collapsed the two tasks into one distro-aware `raw` task that probes for `apt-get` vs `pacman` and installs `python3` accordingly (fails loudly on unsupported distros).

## Verification
- `bash -n setup.sh`
- Committed playbook parses as exactly one YAML document
- Simulated the generator's `bootstrap_play + main_play_header` concat: output is one document, one bootstrap task
- `git diff` limited to `setup.sh` + `playbook-supabase.yml`

## Test plan (draft)
Deploy on Ubuntu/Debian: `./setup.sh` → bootstrap now passes and the stack deploys; then exercise the manifest (`/etc/supabase/instance.json`), the `supabase-agent` MCP endpoint over SSH stdio, and the `supabase-selfhosted` info CLI (see `docs/test-cases/issue-120.md`).