### PR TITLE
fix(agent_access): remove self-referential python interpreter var

### DIFF
--- a/roles/agent_access/tasks/main.yml
+++ b/roles/agent_access/tasks/main.yml
@@ -28,7 +28,7 @@
   register: agent_keypair_result
   become: true
   vars:
-    ansible_python_interpreter: "{{ ansible_playbook_python | default(ansible_python_interpreter | default('python3')) }}"
+    ansible_python_interpreter: "{{ ansible_playbook_python | default('python3') }}"
 
 - name: Generate ed25519 agent keypair (fallback)
   ansible.builtin.command:


### PR DESCRIPTION
## What this fixes

Deploy blocker shipped by the instance-manifest/SSH-agent PR (#123) — hits every deployment.

### Symptom

The `agent_access : Generate ed25519 agent keypair (community.crypto)` task fails on every run with:

```
fatal: [localhost]: FAILED! => recursive loop detected in template string:
{{ ansible_playbook_python | default(ansible_python_interpreter | default('python3')) }}.
maximum recursion depth exceeded
```

In that expression, `ansible_python_interpreter` is being defined **in terms of itself**: the var is the very name being resolved inside its own `default()` argument. Ansible's Templar resolves the name, which pulls the value, whose template references the name again → infinite recursion. A plain Jinja2 render doesn't hit this (Jinja's `default` short-circuits undefined), only Ansible's variable resolver does, which is why it survived review.

### Fix

```yaml
# before
ansible_python_interpreter: "{{ ansible_playbook_python | default(ansible_python_interpreter | default('python3')) }}"
# after
ansible_python_interpreter: "{{ ansible_playbook_python | default('python3') }}"
```

`ansible_playbook_python` is a controller-side magic var, always defined for these `localhost` plays, so the intent (pin the `community.crypto` module to the interpreter that hosts `cryptography`) is preserved with no self-reference.

Note the resilience path is untouched: if `community.crypto` still can't run, the existing `Generate ed25519 agent keypair (fallback)` task (`ssh-keygen`, `when: agent_keypair_result is failed`) takes over automatically.

## Change
- `roles/agent_access/tasks/main.yml` — one line, removes the recursive self-reference.

## Test status
Verified on a live Ubuntu deploy alongside the #123 feature pass: the keypair task now completes via the fallback/community path and the role finishes (recap prints the restricted key). Full checklist tracked in the #123 test docs (`docs/test-cases/issue-120.md`).