### PR TITLE
fix(agent_access): repair supabase-agent query and list_tables MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 # Ansible retry files
 *.retry
 
+# Python bytecode cache
+__pycache__/
+*.pyc
+
 # Editor / OS
 .DS_Store
 *.swp

--- a/roles/agent_access/files/supabase-agent
+++ b/roles/agent_access/files/supabase-agent
@@ -95,18 +95,18 @@ def _db_container(manifest: Dict[str, Any]) -> str:
     return str(manifest.get("containers", {}).get("db", "supabase-db"))
 
 
-def _psql(db: str, sql: str, flags: str = "-c") -> Tuple[int, str, str]:
+def _psql(db: str, sql: str, flags: Tuple[str, ...] = ("-c",)) -> Tuple[int, str, str]:
     return _run([
         "docker", "exec", db, "psql",
-        "-U", "postgres", "-d", "postgres", flags, sql,
+        "-U", "postgres", "-d", "postgres", *flags, sql,
     ])
 
 
-def tool_list_tables(manifest: Dict[str, Any]) -> Dict[str, Any]:
+def tool_list_tables(_args: Dict[str, Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
     sql = "SELECT schemaname || '.' || tablename FROM pg_tables " \
           "WHERE schemaname NOT IN ('pg_catalog','information_schema') " \
           "ORDER BY 1;"
-    rc, out, err = _psql(_db_container(manifest), sql, flags="-t -A -F $'\\t'")
+    rc, out, err = _psql(_db_container(manifest), sql, flags=("-t", "-A", "-c"))
     if rc != 0:
         return _tool_error(f"psql failed (rc={rc}): {err.strip()}")
     return _tool_text(out)
@@ -142,7 +142,7 @@ def tool_query(args: Dict[str, Any], manifest: Dict[str, Any]) -> Dict[str, Any]
         if re.search(rf"\b{verb}\b", upper):
             return _tool_error(f"forbidden verb in query: {verb}")
 
-    rc, out, err = _psql(_db_container(manifest), sql, flags="-t -A -F $'\\t'")
+    rc, out, err = _psql(_db_container(manifest), sql, flags=("-t", "-A", "-c"))
     if rc != 0:
         return _tool_error(f"psql failed (rc={rc}): {err.strip()}")
     return _tool_text(out)


### PR DESCRIPTION
## Summary

Repairs the read-only `supabase-agent` MCP tools (`query`, `list_tables`) which were broken on live instances by three separate bugs in `roles/agent_access/files/supabase-agent`:

### 1. `tool_list_tables` arity mismatch
The dispatcher calls every tool as `TOOL_DISPATCH[name](args, manifest)`, but `tool_list_tables` declared only `(manifest)`. Every call raised `TypeError: tool_list_tables() takes 1 positional argument but 2 were given`.

### 2. psql flags passed as a single argv element
`_psql` appended the flag string `"-t -A -F $'\t'"` as one argv entry. psql's getopt read the embedded spaces and died with `psql: invalid option -- ' '`. The `$'\t'` bash-ism never expands inside an argv array, so it could never have worked; unaligned (`-A`) output already defaults to tab-separated fields anyway.

### 3. Missing `-c` flag
The `query`/`list_tables` flag set omitted `-c`, so psql treated the SQL as an extra positional argument, silently ignored it, and exited 0 with empty output — tools returned empty results with no error.

## Changes

- `super... [_psql]`: splat flags as separate argv entries (`*flags`) instead of one string; default stays `("-c",)`.
- `tool_list_tables`: two-arg signature `(_args, manifest)` matching the dispatcher.
- `query`/`list_tables` now call `_psql(..., flags=("-t", "-A", "-c"))`.
- `.gitignore`: add `__pycache__/` and `*.pyc` (bytecode cache residue from verification).

## Verification

- `python3 -m py_compile` passes.
- Local JSON-RPC simulation: `query SELECT 1` → `1`, `list_tables` returns table list; `DELETE ...` still blocked (`only SELECT/WITH queries are allowed`).
- Deployed binary updated and confirmed working end-to-end via a fresh MCP session (`select 1`, `list_tables`, `describe_table`, `list_containers`, `container_status`, `get_manifest`).