### PR TITLE
ci: unbreak main, move the full sweep to release time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,35 @@ permissions:
 
 jobs:
   # ───────────────────────────────────────────────────────────────────────────
+  # Does this PR touch anything that can change a deployment? A docs-only or
+  # workflow-only change has no business spending fifteen minutes bringing up
+  # the Supabase stack.
+  # ───────────────────────────────────────────────────────────────────────────
+  changes:
+    name: Detect deployment-affecting changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      deploy: ${{ steps.filter.outputs.deploy }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        run: |
+          git fetch --quiet origin "${{ github.base_ref }}"
+          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          echo "Changed files:"; echo "$changed"
+          if echo "$changed" | grep -qE '^(roles/|tests/|scripts/|env/|\.github/workflows/|setup\.sh|install\.sh|generate-keys\.sh|migrate\.sh|requirements\.yml|config\.example\.yml|[^/]+\.yml)'; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "→ integration will run"
+          else
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "→ integration skipped (no deployment-affecting files)"
+          fi
+
+  # ───────────────────────────────────────────────────────────────────────────
   # Fast gate. Runs on every PR, finishes in about a minute.
   # ───────────────────────────────────────────────────────────────────────────
   lint:
@@ -104,12 +133,19 @@ jobs:
   # throwaway VM with sudo and Docker, which is exactly the target this
   # playbook expects — no external server needed.
   #
+  # This is the *smoke* deployment: one distro, the components that matter
+  # most, enough to catch a broken role before it reaches main. The full
+  # sweep — every component, LUKS, restore drills, both Ubuntu versions —
+  # runs at release time in release.yml.
+  #
   # Not covered here: Caddy, TLS and SSO. Let's Encrypt needs public DNS and
   # port 80 reachable, which a runner does not have. UFW is left off so the
   # job cannot firewall itself mid-run.
   # ───────────────────────────────────────────────────────────────────────────
   integration:
     name: Integration (deploy, idempotence, backup/restore)
+    needs: changes
+    if: needs.changes.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -132,17 +130,20 @@ jobs:
       - name: Report available disk
         run: df -h /
 
+      # Domains use the reserved .invalid TLD (RFC 2606): guaranteed never to
+      # resolve, and — unlike sb.example.com — not on the placeholder deny-list
+      # that roles/supabase asserts against.
       - name: Write config.yml
         run: |
           cat > config.yml <<'YAML'
           required:
             deploy_user: runner
-            site_url: https://app.example.com
-            api_external_url: https://sb.example.com
-            supabase_domain: sb.example.com
-            smtp_admin_email: ci@example.com
-            smtp_host: smtp.example.com
-            smtp_user: ci@example.com
+            site_url: https://app.ci.invalid
+            api_external_url: https://sb.ci.invalid
+            supabase_domain: sb.ci.invalid
+            smtp_admin_email: ci@ci.invalid
+            smtp_host: smtp.ci.invalid
+            smtp_user: ci@ci.invalid
             smtp_password: ci-not-a-real-password
 
           secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,259 @@
+---
+# The full sweep. Everything the PR gate deliberately skips runs here.
+#
+# Three triggers, one suite:
+#
+#   release    — the gate that blocks shipping a version
+#   schedule   — weekly, because roles/supabase clones the *latest* upstream
+#                Supabase release. This stack can break with nobody touching
+#                this repo, and a weekly run is the only thing that catches
+#                that before a user does.
+#   dispatch   — run it by hand when you want to.
+#
+# Runner coverage is Ubuntu-only: GitHub-hosted runners do not offer Debian or
+# Arch images. The README claims those as supported targets, and nothing here
+# proves it — covering them needs a self-hosted runner or a VM provider.
+
+name: Release
+
+on:
+  release:
+    types: [published]
+  schedule:
+    - cron: '0 4 * * 1'     # Mondays, 04:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────────────
+  # Full deployment with every component the runner can host, on both
+  # supported Ubuntu versions.
+  # ───────────────────────────────────────────────────────────────────────────
+  full-stack:
+    name: Full stack (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Install asciinema
+        run: pipx install asciinema || pip install --quiet asciinema
+
+      # Unlike the PR gate, this turns on monitoring and fail2ban too. Caddy
+      # stays off (Let's Encrypt needs public DNS) and UFW stays off (the job
+      # would firewall itself).
+      - name: Write config.yml
+        run: |
+          cat > config.yml <<'YAML'
+          required:
+            deploy_user: runner
+            site_url: https://app.ci.invalid
+            api_external_url: https://sb.ci.invalid
+            supabase_domain: sb.ci.invalid
+            smtp_admin_email: ci@ci.invalid
+            smtp_host: smtp.ci.invalid
+            smtp_user: ci@ci.invalid
+            smtp_password: ci-not-a-real-password
+
+          secrets:
+            generate: true
+
+          components:
+            caddy: false
+            monitor: true
+            fail2ban: true
+            backup: true
+            ufw: false
+            luks: false
+
+          advanced:
+            backup:
+              repo_type: minio
+          YAML
+
+      # Recorded rather than run plainly: the deploy is the demo. `-i 2` caps
+      # idle gaps at two seconds, which turns a ten-minute install into
+      # something a reader will actually watch.
+      - name: Deploy (recorded)
+        run: |
+          asciinema rec install.cast \
+            --overwrite -i 2 \
+            --title "supabase-selfhost-ops — one-command install" \
+            -c "sudo bash setup.sh --yes"
+
+      - name: Wait for containers to become healthy
+        run: |
+          for i in $(seq 1 90); do
+            unhealthy=$(sudo docker ps --format '{{.Names}}\t{{.Status}}' \
+              | grep -c 'unhealthy\|starting' || true)
+            if [ "$unhealthy" -eq 0 ]; then
+              echo "All containers settled after ${i}0s."
+              sudo docker ps --format '{{.Names}}\t{{.Status}}'
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Containers did not become healthy within 15 minutes."
+          sudo docker ps --format '{{.Names}}\t{{.Status}}'
+          exit 1
+
+      - name: Smoke test the API gateway
+        run: |
+          anon_key=$(sudo grep -oP '^sb_anon_key:\s*\K\S+' env/supabase.yml)
+          curl -fsS -H "apikey: ${anon_key}" http://localhost:8000/rest/v1/ > /dev/null
+          echo "Kong routed a REST request successfully."
+
+      - name: Smoke test Grafana
+        run: |
+          curl -fsS http://localhost:3002/api/health | tee /dev/stderr | grep -q '"database"'
+
+      - name: On-demand backup
+        run: sudo ansible-playbook -i localhost, -c local backup.yml -e @env/supabase.yml
+
+      - name: Restore drill (non-destructive)
+        run: |
+          sudo ansible-playbook -i localhost, -c local restore-verify.yml \
+            -e @env/supabase.yml
+
+      - name: Record the upstream Supabase release under test
+        run: |
+          ref=$(sudo git -C /home/runner/supabase describe --tags 2>/dev/null \
+            || sudo git -C /home/runner/supabase rev-parse --short HEAD 2>/dev/null \
+            || echo unknown)
+          echo "Supabase upstream under test: ${ref}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the recording
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-cast
+          path: install.cast
+
+      - name: Container logs on failure
+        if: failure()
+        run: |
+          sudo docker ps -a --format '{{.Names}}\t{{.Status}}'
+          for c in $(sudo docker ps -aq); do
+            echo "──────── $(sudo docker inspect --format '{{.Name}}' "$c")"
+            sudo docker logs --tail 80 "$c" 2>&1 || true
+          done
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # LUKS against a loopback device. Advisory for now: the role is exercised
+  # here for the first time, and a harness problem should not block a release.
+  # Drop continue-on-error once this has passed once.
+  # ───────────────────────────────────────────────────────────────────────────
+  luks:
+    name: LUKS (loopback device)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create a loopback block device
+        run: |
+          sudo fallocate -l 2G /tmp/luks.img
+          echo "LUKS_DEV=$(sudo losetup --find --show /tmp/luks.img)" >> "$GITHUB_ENV"
+
+      - name: Write config.yml
+        run: |
+          cat > config.yml <<YAML
+          required:
+            deploy_user: runner
+            site_url: https://app.ci.invalid
+            api_external_url: https://sb.ci.invalid
+            supabase_domain: sb.ci.invalid
+            smtp_admin_email: ci@ci.invalid
+            smtp_host: smtp.ci.invalid
+            smtp_user: ci@ci.invalid
+            smtp_password: ci-not-a-real-password
+
+          secrets:
+            generate: true
+
+          components:
+            caddy: false
+            monitor: false
+            fail2ban: false
+            backup: false
+            ufw: false
+            luks: true
+
+          advanced:
+            luks:
+              device: ${LUKS_DEV}
+              mount_point: /data
+          YAML
+
+      - name: Deploy with LUKS enabled
+        run: sudo bash setup.sh --yes
+
+      - name: Assert the volume is encrypted and mounted
+        run: |
+          sudo cryptsetup status "$(basename "${LUKS_DEV}")" || true
+          mountpoint -q /data && echo "/data is mounted."
+          sudo blkid "${LUKS_DEV}" | grep -q crypto_LUKS
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Turn the recorded install into an animated SVG and commit it, so the
+  # README demo is a byproduct of a passing release rather than a staged clip.
+  # Release only — the weekly run should not rewrite the repo.
+  # ───────────────────────────────────────────────────────────────────────────
+  publish-demo:
+    name: Publish install demo
+    needs: full-stack
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: install-cast
+
+      - name: Render to animated SVG
+        run: |
+          mkdir -p docs/assets
+          npx --yes svg-term-cli \
+            --in install.cast \
+            --out docs/assets/install.svg \
+            --window --width 100 --height 30
+
+      - name: Commit if it changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/assets/install.svg
+          if git diff --cached --quiet; then
+            echo "Demo unchanged."
+          else
+            git commit -m "docs(demo): refresh install recording from ${GITHUB_REF_NAME}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ component, or rebuild the box — not a one-shot script you can never run twice.
 
 ### Prerequisites
 
-- A **Debian 12, Ubuntu 22.04/24.04, or Arch Linux server** with root or sudo access (see the [server support matrix](#server-support-matrix) above)
+- A **Debian 12, Ubuntu 22.04/24.04, or Arch Linux server** with root or sudo access
 - A **domain** with three DNS A records pointing to your server:
   - `sb.example.com` — Supabase dashboard + API
   - `auth.example.com` — OAuth2 authentication endpoint


### PR DESCRIPTION
## Summary

Two things: **`main` is currently red and this fixes it**, and the heavy suite moves to release time per review feedback on #129.

## The urgent half

#129 merged at `b8dc5c0`, one commit before the fix for the integration job. Every CI run since has failed — on `main` and on #131, #132 and #134 — for one reason:

```
TASK [supabase : Ensure Supabase public domain is configured]
fatal: "projects.supabase.domain is not set to a real public domain"
```

`roles/supabase` asserts the domain is not a placeholder, and the CI config used `sb.example.com`, which is on that deny-list by name. The guard was right; the config was wrong. Domains now use the reserved `.invalid` TLD (RFC 2606) — guaranteed never to resolve, and not a value any deny-list reads as "you forgot to fill this in".

## The scoping half

Running the full deployment on every push to `main` is disproportionate, and the same is true of running it on PRs that cannot affect a deployment. The split is now by what each moment can actually catch:

**Pull requests** — `lint` and `unit` always, about a minute together. `integration` only when the PR touches roles, scripts, playbooks, requirements or workflows. A docs-only PR skips it entirely. The filter is a plain `git diff`, so no third-party action is involved.

**Releases, weekly, and on demand** — the full sweep in a new `release.yml`:

- full stack on `ubuntu-22.04` and `ubuntu-24.04`, with monitoring and fail2ban on as well as backups
- Grafana and Kong smoke tests, on-demand backup, non-destructive restore drill
- LUKS against a loopback device — advisory until it has passed once, so an unproven harness cannot block a release
- the **weekly** trigger is the one that earns the most here: `roles/supabase` clones the *latest* upstream release, so this stack can break with nobody touching this repo. The run also records which upstream release was under test.

## Install demo

The README demo becomes a byproduct of a passing release rather than a staged clip: the deploy is recorded with `asciinema` (idle gaps capped at two seconds, which makes a ten-minute install watchable), rendered to an animated SVG, and committed to `docs/assets/install.svg` on release only. It first appears with the first release — the README placeholder stays until then rather than pointing at a file that does not exist.

## Worth knowing

**Runner coverage is Ubuntu-only.** GitHub-hosted runners offer no Debian or Arch image. The README lists both as supported targets and nothing here proves it — that needs a self-hosted runner or a VM provider. Flagging rather than quietly implying coverage.

Also fixes a README link to the server support matrix, a section removed in 73b4c97.

## Test plan

- [x] Both workflows parse; `yamllint`, `shellcheck -S error` and the README anchor check are clean locally
- [x] Clone path (`/home/runner/supabase`) and Grafana port (`3002`) verified against the roles rather than assumed
- [ ] Integration green on this PR — the first real proof of the `.invalid` fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eodum5y2AQHTzVa6nYthN5)_